### PR TITLE
Xml updates for YOG

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1412,6 +1412,8 @@
 <deep_scheme phys='spcam_sam1mom'>SPCAM    </deep_scheme>
 <deep_scheme phys='spcam_m2005'  >SPCAM    </deep_scheme>
 
+<run_deep_comp>off </run_deep_comp>
+
 <shallow_scheme pbl="none"         >NONE     </shallow_scheme>
 <shallow_scheme pbl="uw"           >UW       </shallow_scheme>
 <shallow_scheme pbl="uw" unicon="1">UNICON   </shallow_scheme>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1412,7 +1412,9 @@
 <deep_scheme phys='spcam_sam1mom'>SPCAM    </deep_scheme>
 <deep_scheme phys='spcam_m2005'  >SPCAM    </deep_scheme>
 
-<run_deep_comp>off </run_deep_comp>
+<nn_weights                      >NONE</nn_weights>
+<SAM_sounding                    >NONE</SAM_sounding>
+<run_deep_comp                   >off </run_deep_comp>
 
 <shallow_scheme pbl="none"         >NONE     </shallow_scheme>
 <shallow_scheme pbl="uw"           >UW       </shallow_scheme>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1412,6 +1412,7 @@
 <deep_scheme phys='spcam_sam1mom'>SPCAM    </deep_scheme>
 <deep_scheme phys='spcam_m2005'  >SPCAM    </deep_scheme>
 
+<yog_scheme                      >off </yog_scheme>
 <nn_weights                      >NONE</nn_weights>
 <SAM_sounding                    >NONE</SAM_sounding>
 

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1414,7 +1414,6 @@
 
 <nn_weights                      >NONE</nn_weights>
 <SAM_sounding                    >NONE</SAM_sounding>
-<run_deep_comp                   >off </run_deep_comp>
 
 <shallow_scheme pbl="none"         >NONE     </shallow_scheme>
 <shallow_scheme pbl="uw"           >UW       </shallow_scheme>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2962,6 +2962,14 @@ distinquish shallow and deep.
 Default: 'ZM' unless using 'UNICON', 'SPCAM' or 'pbl=none'
 </entry>
 
+<entry id="run_deep_comp" type="char*16" category="conv"
+       group="phys_ctl_nl" valid_values="off,on">
+Whether or not to use both schemes for deep convection.
+   'off' just run scheme specified by deep_scheme
+   'on'  use scheme specified by deep_scheme, but also run other to compare
+Default: off
+</entry>
+
 <entry id="nn_weights" type="char*132" input_pathname="abs" category="conv"
        group="phys_ctl_nl" valid_values="" >
 Path to the neural net weights used for the YOG deep convection scheme

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2955,19 +2955,10 @@ Default: 10
 <!-- Moist Convection and Microphysics -->
 
 <entry id="deep_scheme" type="char*16" category="conv"
-       group="phys_ctl_nl" valid_values="ZM,UNICON,off,CLUBB_SGS,YOG" >
+       group="phys_ctl_nl" valid_values="ZM,UNICON,off,CLUBB_SGS" >
 Type of deep convection scheme employed.  'ZM' for Zhang-McFarlane;
-'off' for none;'YOG' for Yanni-O'Gorman; or 'UNICON' which doesn't
-distinquish shallow and deep.
+'off' for none; or 'UNICON' which doesn't distinquish shallow and deep.
 Default: 'ZM' unless using 'UNICON', 'SPCAM' or 'pbl=none'
-</entry>
-
-<entry id="run_deep_comp" type="char*16" category="conv"
-       group="phys_ctl_nl" valid_values="off,on">
-Whether or not to use both schemes for deep convection.
-   'off' just run scheme specified by deep_scheme
-   'on'  use scheme specified by deep_scheme, but also run other to compare
-Default: off
 </entry>
 
 <entry id="nn_weights" type="char*132" input_pathname="abs" category="conv"

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2962,6 +2962,16 @@ distinquish shallow and deep.
 Default: 'ZM' unless using 'UNICON', 'SPCAM' or 'pbl=none'
 </entry>
 
+<entry id="nn_weights" type="char*132" input_pathname="abs" category="conv"
+       group="phys_ctl_nl" valid_values="" >
+Path to the neural net weights used for the YOG deep convection scheme
+</entry>
+
+<entry id="SAM_sounding" type="char*132" input_pathname="abs" category="conv"
+       group="phys_ctl_nl" valid_values="" >
+Path to the SAM sounding profile used for the YOG deep convection scheme
+</entry>
+
 <entry id="microp_scheme" type="char*16" category="conv"
        group="phys_ctl_nl" valid_values="RK,MG,SPCAM_m2005,SPCAM_sam1mom" >
 Type of microphysics scheme employed.  'RK' for Rasch and Kristjansson

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2955,9 +2955,10 @@ Default: 10
 <!-- Moist Convection and Microphysics -->
 
 <entry id="deep_scheme" type="char*16" category="conv"
-       group="phys_ctl_nl" valid_values="ZM,UNICON,off,CLUBB_SGS" >
+       group="phys_ctl_nl" valid_values="ZM,UNICON,off,CLUBB_SGS,YOG" >
 Type of deep convection scheme employed.  'ZM' for Zhang-McFarlane;
-'off' for none; or 'UNICON' which doesn't distinquish shallow and deep.
+'off' for none;'YOG' for Yanni-O'Gorman; or 'UNICON' which doesn't
+distinquish shallow and deep.
 Default: 'ZM' unless using 'UNICON', 'SPCAM' or 'pbl=none'
 </entry>
 

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2961,16 +2961,6 @@ Type of deep convection scheme employed.  'ZM' for Zhang-McFarlane;
 Default: 'ZM' unless using 'UNICON', 'SPCAM' or 'pbl=none'
 </entry>
 
-<entry id="nn_weights" type="char*132" input_pathname="abs" category="conv"
-       group="phys_ctl_nl" valid_values="" >
-Path to the neural net weights used for the YOG deep convection scheme
-</entry>
-
-<entry id="SAM_sounding" type="char*132" input_pathname="abs" category="conv"
-       group="phys_ctl_nl" valid_values="" >
-Path to the SAM sounding profile used for the YOG deep convection scheme
-</entry>
-
 <entry id="microp_scheme" type="char*16" category="conv"
        group="phys_ctl_nl" valid_values="RK,MG,SPCAM_m2005,SPCAM_sam1mom" >
 Type of microphysics scheme employed.  'RK' for Rasch and Kristjansson
@@ -3004,6 +2994,13 @@ Type of shallow convection scheme employed.
  'SPCAM_m2005' for SPCAM double moment
  'SPCAM_sam1mom' for SPCAM single moment
 Default: set by build-namelist (depends on {{ hilight }}eddy_scheme{{ closehilight }}).
+</entry>
+
+<entry id="yog_scheme" type="char*16" category="conv"
+       group="phys_ctl_nl" valid_values="on,off" >
+Whether to run the Yuval-O'Gorman Scheme.
+'off' for no running; or 'on' to run.
+Default: 'off'.
 </entry>
 
 <entry id="do_beljaars" type="logical" category="pbl"
@@ -3277,6 +3274,17 @@ Default: false
 Apply adjustments to dry static energy so that CLUBB conserves
 energy.
 Default: true
+</entry>
+
+<!-- YOG parameters -->
+<entry id="nn_weights" type="char*132" input_pathname="abs" category="conv"
+       group="yog_params_nl" valid_values="" >
+Absolute path to the neural net weights used for the YOG deep convection scheme.
+</entry>
+
+<entry id="SAM_sounding" type="char*132" input_pathname="abs" category="conv"
+       group="yog_params_nl" valid_values="" >
+Absolute path to the SAM sounding profile used for the YOG deep convection scheme.
 </entry>
 
 <!-- CARMA Sectional Microphysics -->

--- a/src/physics/cam/phys_control.F90
+++ b/src/physics/cam/phys_control.F90
@@ -39,8 +39,9 @@ character(len=16) :: cam_physpkg          = unset_str  ! CAM physics package
 character(len=32) :: cam_chempkg          = unset_str  ! CAM chemistry package 
 character(len=16) :: waccmx_opt           = unset_str  ! WACCMX run option [ionosphere | neutral | off
 character(len=16) :: deep_scheme          = unset_str  ! deep convection package
-character(len=132) :: nn_weights         = unset_str  ! location of weights for the YOG NN, set in namelist
-character(len=132) :: SAM_sounding       = unset_str  ! location of SAM sounding
+character(len=132) :: nn_weights          = unset_str  ! location of weights for the YOG NN, set in namelist
+character(len=132) :: SAM_sounding        = unset_str  ! location of SAM sounding
+character(len=16) :: run_deep_comp        = unset_str  ! run comparison of deep convection schemes (ZM and YOG)
 character(len=16) :: shallow_scheme       = unset_str  ! shallow convection package
 character(len=16) :: eddy_scheme          = unset_str  ! vertical diffusion package
 character(len=16) :: microp_scheme        = unset_str  ! microphysics package
@@ -128,7 +129,7 @@ subroutine phys_ctl_readnl(nlfile)
       history_cesm_forcing, history_scwaccm_forcing, history_chemspecies_srf, &
       do_clubb_sgs, state_debug_checks, use_hetfrz_classnuc, use_gw_oro, use_gw_front, &
       use_gw_front_igw, use_gw_convect_dp, use_gw_convect_sh, cld_macmic_num_steps, &
-      offline_driver, convproc_do_aer, nn_weights, SAM_sounding
+      offline_driver, convproc_do_aer, nn_weights, SAM_sounding, run_deep_comp
    !-----------------------------------------------------------------------------
 
    if (masterproc) then
@@ -188,6 +189,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpi_bcast(convproc_do_aer,             1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(nn_weights,                  len(nn_weights),       mpi_character, masterprocid, mpicom, ierr)
    call mpi_bcast(SAM_sounding,                len(SAM_sounding),     mpi_character, masterprocid, mpicom, ierr)
+   call mpi_bcast(run_deep_comp,               len(run_deep_comp),    mpi_character, masterprocid, mpicom, ierr)
 
    use_spcam       = (     cam_physpkg_is('spcam_sam1mom') &
                       .or. cam_physpkg_is('spcam_m2005'))
@@ -284,7 +286,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
                         history_cesm_forcing_out, history_scwaccm_forcing_out, history_chemspecies_srf_out, &
                         cam_chempkg_out, prog_modal_aero_out, macrop_scheme_out, &
                         do_clubb_sgs_out, use_spcam_out, state_debug_checks_out, cld_macmic_num_steps_out, &
-                        offline_driver_out, convproc_do_aer_out, nn_weights_out, SAM_sounding_out)
+                        offline_driver_out, convproc_do_aer_out, nn_weights_out, SAM_sounding_out, run_deep_comp_out)
 !-----------------------------------------------------------------------
 ! Purpose: Return runtime settings
 !          deep_scheme_out   : deep convection scheme
@@ -298,6 +300,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
    character(len=16), intent(out), optional :: deep_scheme_out
    character(len=136), intent(out), optional  :: nn_weights_out
    character(len=136), intent(out), optional  :: SAM_sounding_out
+   character(len=16), intent(out), optional :: run_deep_comp_out
    character(len=16), intent(out), optional :: shallow_scheme_out
    character(len=16), intent(out), optional :: eddy_scheme_out
    character(len=16), intent(out), optional :: microp_scheme_out
@@ -333,6 +336,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
    if ( present(deep_scheme_out         ) ) deep_scheme_out          = deep_scheme
    if ( present(nn_weights_out          ) ) nn_weights_out           = nn_weights
    if ( present(SAM_sounding_out        ) ) SAM_sounding_out         = SAM_sounding
+   if ( present(run_deep_comp_out       ) ) run_deep_comp_out        = run_deep_comp
    if ( present(shallow_scheme_out      ) ) shallow_scheme_out       = shallow_scheme
    if ( present(eddy_scheme_out         ) ) eddy_scheme_out          = eddy_scheme
    if ( present(microp_scheme_out       ) ) microp_scheme_out        = microp_scheme

--- a/src/physics/cam/phys_control.F90
+++ b/src/physics/cam/phys_control.F90
@@ -41,7 +41,6 @@ character(len=16) :: waccmx_opt           = unset_str  ! WACCMX run option [iono
 character(len=16) :: deep_scheme          = unset_str  ! deep convection package
 character(len=132) :: nn_weights          = unset_str  ! location of weights for the YOG NN, set in namelist
 character(len=132) :: SAM_sounding        = unset_str  ! location of SAM sounding
-character(len=16) :: run_deep_comp        = unset_str  ! run comparison of deep convection schemes (ZM and YOG)
 character(len=16) :: shallow_scheme       = unset_str  ! shallow convection package
 character(len=16) :: eddy_scheme          = unset_str  ! vertical diffusion package
 character(len=16) :: microp_scheme        = unset_str  ! microphysics package
@@ -129,7 +128,7 @@ subroutine phys_ctl_readnl(nlfile)
       history_cesm_forcing, history_scwaccm_forcing, history_chemspecies_srf, &
       do_clubb_sgs, state_debug_checks, use_hetfrz_classnuc, use_gw_oro, use_gw_front, &
       use_gw_front_igw, use_gw_convect_dp, use_gw_convect_sh, cld_macmic_num_steps, &
-      offline_driver, convproc_do_aer, nn_weights, SAM_sounding, run_deep_comp
+      offline_driver, convproc_do_aer, nn_weights, SAM_sounding
    !-----------------------------------------------------------------------------
 
    if (masterproc) then
@@ -189,7 +188,6 @@ subroutine phys_ctl_readnl(nlfile)
    call mpi_bcast(convproc_do_aer,             1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(nn_weights,                  len(nn_weights),       mpi_character, masterprocid, mpicom, ierr)
    call mpi_bcast(SAM_sounding,                len(SAM_sounding),     mpi_character, masterprocid, mpicom, ierr)
-   call mpi_bcast(run_deep_comp,               len(run_deep_comp),    mpi_character, masterprocid, mpicom, ierr)
 
    use_spcam       = (     cam_physpkg_is('spcam_sam1mom') &
                       .or. cam_physpkg_is('spcam_m2005'))
@@ -286,7 +284,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
                         history_cesm_forcing_out, history_scwaccm_forcing_out, history_chemspecies_srf_out, &
                         cam_chempkg_out, prog_modal_aero_out, macrop_scheme_out, &
                         do_clubb_sgs_out, use_spcam_out, state_debug_checks_out, cld_macmic_num_steps_out, &
-                        offline_driver_out, convproc_do_aer_out, nn_weights_out, SAM_sounding_out, run_deep_comp_out)
+                        offline_driver_out, convproc_do_aer_out, nn_weights_out, SAM_sounding_out)
 !-----------------------------------------------------------------------
 ! Purpose: Return runtime settings
 !          deep_scheme_out   : deep convection scheme
@@ -300,7 +298,6 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
    character(len=16), intent(out), optional :: deep_scheme_out
    character(len=136), intent(out), optional  :: nn_weights_out
    character(len=136), intent(out), optional  :: SAM_sounding_out
-   character(len=16), intent(out), optional :: run_deep_comp_out
    character(len=16), intent(out), optional :: shallow_scheme_out
    character(len=16), intent(out), optional :: eddy_scheme_out
    character(len=16), intent(out), optional :: microp_scheme_out
@@ -336,7 +333,6 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
    if ( present(deep_scheme_out         ) ) deep_scheme_out          = deep_scheme
    if ( present(nn_weights_out          ) ) nn_weights_out           = nn_weights
    if ( present(SAM_sounding_out        ) ) SAM_sounding_out         = SAM_sounding
-   if ( present(run_deep_comp_out       ) ) run_deep_comp_out        = run_deep_comp
    if ( present(shallow_scheme_out      ) ) shallow_scheme_out       = shallow_scheme
    if ( present(eddy_scheme_out         ) ) eddy_scheme_out          = eddy_scheme
    if ( present(microp_scheme_out       ) ) microp_scheme_out        = microp_scheme

--- a/src/physics/cam/phys_control.F90
+++ b/src/physics/cam/phys_control.F90
@@ -39,6 +39,8 @@ character(len=16) :: cam_physpkg          = unset_str  ! CAM physics package
 character(len=32) :: cam_chempkg          = unset_str  ! CAM chemistry package 
 character(len=16) :: waccmx_opt           = unset_str  ! WACCMX run option [ionosphere | neutral | off
 character(len=16) :: deep_scheme          = unset_str  ! deep convection package
+character(len=132) :: nn_weights         = unset_str  ! location of weights for the YOG NN, set in namelist
+character(len=132) :: SAM_sounding       = unset_str  ! location of SAM sounding
 character(len=16) :: shallow_scheme       = unset_str  ! shallow convection package
 character(len=16) :: eddy_scheme          = unset_str  ! vertical diffusion package
 character(len=16) :: microp_scheme        = unset_str  ! microphysics package
@@ -126,7 +128,7 @@ subroutine phys_ctl_readnl(nlfile)
       history_cesm_forcing, history_scwaccm_forcing, history_chemspecies_srf, &
       do_clubb_sgs, state_debug_checks, use_hetfrz_classnuc, use_gw_oro, use_gw_front, &
       use_gw_front_igw, use_gw_convect_dp, use_gw_convect_sh, cld_macmic_num_steps, &
-      offline_driver, convproc_do_aer
+      offline_driver, convproc_do_aer, nn_weights, SAM_sounding
    !-----------------------------------------------------------------------------
 
    if (masterproc) then
@@ -184,6 +186,8 @@ subroutine phys_ctl_readnl(nlfile)
    call mpi_bcast(cld_macmic_num_steps,        1,                     mpi_integer,   masterprocid, mpicom, ierr)
    call mpi_bcast(offline_driver,              1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(convproc_do_aer,             1,                     mpi_logical,   masterprocid, mpicom, ierr)
+   call mpi_bcast(nn_weights,                  len(nn_weights),       mpi_character, masterprocid, mpicom, ierr)
+   call mpi_bcast(SAM_sounding,                len(SAM_sounding),     mpi_character, masterprocid, mpicom, ierr)
 
    use_spcam       = (     cam_physpkg_is('spcam_sam1mom') &
                       .or. cam_physpkg_is('spcam_m2005'))
@@ -280,7 +284,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
                         history_cesm_forcing_out, history_scwaccm_forcing_out, history_chemspecies_srf_out, &
                         cam_chempkg_out, prog_modal_aero_out, macrop_scheme_out, &
                         do_clubb_sgs_out, use_spcam_out, state_debug_checks_out, cld_macmic_num_steps_out, &
-                        offline_driver_out, convproc_do_aer_out)
+                        offline_driver_out, convproc_do_aer_out, nn_weights_out, SAM_sounding_out)
 !-----------------------------------------------------------------------
 ! Purpose: Return runtime settings
 !          deep_scheme_out   : deep convection scheme
@@ -292,6 +296,8 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
 !-----------------------------------------------------------------------
 
    character(len=16), intent(out), optional :: deep_scheme_out
+   character(len=136), intent(out), optional  :: nn_weights_out
+   character(len=136), intent(out), optional  :: SAM_sounding_out
    character(len=16), intent(out), optional :: shallow_scheme_out
    character(len=16), intent(out), optional :: eddy_scheme_out
    character(len=16), intent(out), optional :: microp_scheme_out
@@ -325,6 +331,8 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
    logical,           intent(out), optional :: convproc_do_aer_out
 
    if ( present(deep_scheme_out         ) ) deep_scheme_out          = deep_scheme
+   if ( present(nn_weights_out          ) ) nn_weights_out           = nn_weights
+   if ( present(SAM_sounding_out        ) ) SAM_sounding_out         = SAM_sounding
    if ( present(shallow_scheme_out      ) ) shallow_scheme_out       = shallow_scheme
    if ( present(eddy_scheme_out         ) ) eddy_scheme_out          = eddy_scheme
    if ( present(microp_scheme_out       ) ) microp_scheme_out        = microp_scheme

--- a/src/physics/cam/physpkg.F90
+++ b/src/physics/cam/physpkg.F90
@@ -52,6 +52,10 @@ module physpkg
   character(len=16) :: shallow_scheme
   character(len=16) :: macrop_scheme
   character(len=16) :: microp_scheme
+  character(len=16) :: deep_scheme    ! default set in phys_control.F90, use namelist to change
+  character(len=136) :: nn_weights    ! location of weights for the YOG NN, set in namelist
+  character(len=136) :: SAM_sounding  ! location of SAM sounding profile for the YOG NN, set in namelist
+  character(len=16) :: run_deep_comp  ! run comparison of deep convection schemes ZM and YOG
   integer           :: cld_macmic_num_steps    ! Number of macro/micro substeps
   logical           :: do_clubb_sgs
   logical           :: use_subcol_microp   ! if true, use subcolumns in microphysics
@@ -157,6 +161,10 @@ contains
 
     ! Get physics options
     call phys_getopts(shallow_scheme_out       = shallow_scheme, &
+                      deep_scheme_out          = deep_scheme, &
+                      nn_weights_out           = nn_weights, &
+                      SAM_sounding_out         = SAM_sounding, &
+                      run_deep_comp_out        = run_deep_comp, &
                       macrop_scheme_out        = macrop_scheme,   &
                       microp_scheme_out        = microp_scheme,   &
                       cld_macmic_num_steps_out = cld_macmic_num_steps, &

--- a/src/physics/cam/physpkg.F90
+++ b/src/physics/cam/physpkg.F90
@@ -55,7 +55,6 @@ module physpkg
   character(len=16) :: deep_scheme    ! default set in phys_control.F90, use namelist to change
   character(len=136) :: nn_weights    ! location of weights for the YOG NN, set in namelist
   character(len=136) :: SAM_sounding  ! location of SAM sounding profile for the YOG NN, set in namelist
-  character(len=16) :: run_deep_comp  ! run comparison of deep convection schemes ZM and YOG
   integer           :: cld_macmic_num_steps    ! Number of macro/micro substeps
   logical           :: do_clubb_sgs
   logical           :: use_subcol_microp   ! if true, use subcolumns in microphysics
@@ -164,7 +163,6 @@ contains
                       deep_scheme_out          = deep_scheme, &
                       nn_weights_out           = nn_weights, &
                       SAM_sounding_out         = SAM_sounding, &
-                      run_deep_comp_out        = run_deep_comp, &
                       macrop_scheme_out        = macrop_scheme,   &
                       microp_scheme_out        = microp_scheme,   &
                       cld_macmic_num_steps_out = cld_macmic_num_steps, &

--- a/src/physics/cam/physpkg.F90
+++ b/src/physics/cam/physpkg.F90
@@ -52,7 +52,6 @@ module physpkg
   character(len=16) :: shallow_scheme
   character(len=16) :: macrop_scheme
   character(len=16) :: microp_scheme
-  character(len=16) :: deep_scheme    ! default set in phys_control.F90, use namelist to change
   character(len=16) :: yog_scheme     ! default set in phys_control.F90, use namelist to change
   integer           :: cld_macmic_num_steps    ! Number of macro/micro substeps
   logical           :: do_clubb_sgs
@@ -159,7 +158,6 @@ contains
 
     ! Get physics options
     call phys_getopts(shallow_scheme_out       = shallow_scheme, &
-                      deep_scheme_out          = deep_scheme, &
                       yog_scheme_out           = yog_scheme, &
                       macrop_scheme_out        = macrop_scheme,   &
                       microp_scheme_out        = microp_scheme,   &

--- a/src/physics/cam/physpkg.F90
+++ b/src/physics/cam/physpkg.F90
@@ -53,8 +53,7 @@ module physpkg
   character(len=16) :: macrop_scheme
   character(len=16) :: microp_scheme
   character(len=16) :: deep_scheme    ! default set in phys_control.F90, use namelist to change
-  character(len=136) :: nn_weights    ! location of weights for the YOG NN, set in namelist
-  character(len=136) :: SAM_sounding  ! location of SAM sounding profile for the YOG NN, set in namelist
+  character(len=16) :: yog_scheme     ! default set in phys_control.F90, use namelist to change
   integer           :: cld_macmic_num_steps    ! Number of macro/micro substeps
   logical           :: do_clubb_sgs
   logical           :: use_subcol_microp   ! if true, use subcolumns in microphysics
@@ -161,8 +160,7 @@ contains
     ! Get physics options
     call phys_getopts(shallow_scheme_out       = shallow_scheme, &
                       deep_scheme_out          = deep_scheme, &
-                      nn_weights_out           = nn_weights, &
-                      SAM_sounding_out         = SAM_sounding, &
+                      yog_scheme_out           = yog_scheme, &
                       macrop_scheme_out        = macrop_scheme,   &
                       microp_scheme_out        = microp_scheme,   &
                       cld_macmic_num_steps_out = cld_macmic_num_steps, &


### PR DESCRIPTION
Closes #1 

This PR:
- adds `YOG` as an option for the deep scheme
- creates namelist variables for `SAM_sounding` and `nn_weights` filepaths
- creates a namelist variable to control running both schemes for comparative results
- Adds these variables to the CAM code to be read in from namelists and assigned