### PR TITLE
Moist-Dry conversions

### DIFF
--- a/src/physics/cam/nn_convection_flux.F90
+++ b/src/physics/cam/nn_convection_flux.F90
@@ -17,7 +17,7 @@ private
 !---------------------------------------------------------------------
 ! public interfaces
 public  nn_convection_flux, nn_convection_flux_init, nn_convection_flux_finalize, &
-        esati, qsati, qsatw, dtqsatw, dtqsati
+        esati, rsati, rsatw, dtrsatw, dtrsati
 
 
 !---------------------------------------------------------------------
@@ -156,7 +156,7 @@ contains
 
         ! Other variables
         real(8),   dimension(nrf) :: omp, fac
-        real(8),   dimension(size(tabs_i, 2)) :: qsat, irhoadz, irhoadzdz
+        real(8),   dimension(size(tabs_i, 2)) :: rsat, irhoadz, irhoadzdz
 
         ! -----------------------------------
         ! variables for NN
@@ -216,9 +216,9 @@ contains
             ! ! If using generalised relative humidity convert non-precip. water content to rel. hum
             !     do k=1,nzm
             !         omn = omegan(tabs(i,j,k))
-            !         qsat(k) = omn * qsatw(tabs(i,j,k),pres(k)) + (1.-omn) * qsati(tabs(i,j,k),pres(k))
+            !         rsat(k) = omn * rsatw(tabs(i,j,k),pres(k)) + (1.-omn) * rsati(tabs(i,j,k),pres(k))
             !     end do
-            !     features(dim_counter+1:dim_counter+input_ver_dim) = real(q_i(i,j,1:input_ver_dim)/qsat(1:input_ver_dim),4)
+            !     features(dim_counter+1:dim_counter+input_ver_dim) = real(q_i(i,j,1:input_ver_dim)/rsat(1:input_ver_dim),4)
             !     dim_counter = dim_counter + input_ver_dim
             ! else
             ! ! if using non-precipitating water as water content
@@ -398,12 +398,14 @@ contains
 
 
     !-----------------------------------------------------------------
-    ! Need qsatw functions to:
+    ! Need rsatw functions to:
     !     - run with rf_uses_rh option (currently unused)
     !     - convert variables in CAM interface
     ! Ripped from SAM model:
     ! https://github.com/yaniyuval/Neural_nework_parameterization/blob/f81f5f695297888f0bd1e0e61524590b4566bf03/sam_code_NN/sat.f90
-
+    ! Note r is used instead of q as q in CAM signifies a moist mixing ratio whilst SAM
+    ! uses dry mixing ratios.
+    !
     ! Saturation vapor pressure and mixing ratio.
     ! Based on Flatau et.al, (JAM, 1992:1507)
 
@@ -431,8 +433,8 @@ contains
     end function esatw
 
 
-    != unit 1 :: qsatw
-    real(8) function qsatw(t,p)
+    != unit 1 :: rsatw
+    real(8) function rsatw(t,p)
       implicit none
       != unit K :: t
       real(8) :: t  ! temperature
@@ -442,8 +444,8 @@ contains
       real(8) :: esat
 
       esat = esatw(t)
-      qsatw = 0.622 * esat/max(esat, p-esat)
-    end function qsatw
+      rsatw = 0.622 * esat/max(esat, p-esat)
+    end function rsatw
 
 
     real(8) function dtesatw(t)
@@ -460,12 +462,12 @@ contains
     end function dtesatw
 
 
-    real(8) function dtqsatw(t,p)
+    real(8) function dtrsatw(t,p)
       implicit none
       real(8) :: t  ! temperature (K)
       real(8) :: p  ! pressure    (mb)
-      dtqsatw=0.622*dtesatw(t)/p
-    end function dtqsatw
+      dtrsatw=0.622*dtesatw(t)/p
+    end function dtrsatw
 
 
     real(8) function esati(t)
@@ -483,8 +485,8 @@ contains
     end function esati
 
 
-    != unit 1 :: qsati
-    real(8) function qsati(t,p)
+    != unit 1 :: rsati
+    real(8) function rsati(t,p)
       implicit none
       != unit t :: K
       real(8) :: t  ! temperature
@@ -495,8 +497,8 @@ contains
       != unit mb :: esat
       real(8) :: esat
       esat = esati(t)
-      qsati = 0.622 * esat/max(esat,p-esat)
-    end function qsati
+      rsati = 0.622 * esat/max(esat,p-esat)
+    end function rsati
 
 
     real(8) function dtesati(t)
@@ -514,12 +516,12 @@ contains
     end function dtesati
 
 
-    real(8) function dtqsati(t,p)
+    real(8) function dtrsati(t,p)
       implicit none
       real(8) :: t  ! temperature (K)
       real(8) :: p  ! pressure    (mb)
-      dtqsati = 0.622 * dtesati(t) / p
-    end function dtqsati
+      dtrsati = 0.622 * dtesati(t) / p
+    end function dtrsati
 
 
 end module nn_convection_flux_mod

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -86,34 +86,41 @@ contains
 
         real(8), intent(in) :: cp_cam
             !! specific heat capacity of dry air from CAM [J/kg/K]
-        real(8), dimension(:,:) :: pres_cam
+        real(8), dimension(:,:), intent(in) :: pres_cam
             !! pressure [Pa] from the CAM model
-        real(8), dimension(:,:) :: pres_int_cam
+        real(8), dimension(:,:), intent(in) :: pres_int_cam
             !! interface pressure [Pa] from the CAM model
-        real(8), dimension(:) :: pres_sfc_cam
+        real(8), dimension(:), intent(in)   :: pres_sfc_cam
             !! surface pressure [Pa] from the CAM model
-        real(8), dimension(:,:) :: tabs_cam
+        real(8), dimension(:,:), intent(in) :: tabs_cam
             !! absolute temperature [K] from the CAM model
-        real(8), dimension(:,:) :: qv_cam, qc_cam, qi_cam
+        real(8), dimension(:,:), intent(in) :: qv_cam, qc_cam, qi_cam
             !! moisture content [kg/kg] from the CAM model
-        real(8), dimension(:) :: precsfc
 
-        ! Outputs on the CAM grid
         real(8), dimension(nx, nz), intent(out) :: dqi, dqv, dqc, ds
-
-        real(8) :: y_in(nx)
-            !! Distance of column from equator (proxy for insolation and sfc albedo)
-
-        real(8), dimension(nx)      :: precsfc_i
-            !! precipitation at surface from one call to parameterisation
+            !! Output tendencies - CAM variables on the CAM grid
+        real(8), dimension(:), intent(out) :: precsfc
+            !! Output surface precipitation in CAM
 
         ! Local input variables on the SAM grid
-        real(8), dimension(nx, nrf) :: r0_sam, tabs0_sam
-        real(8), dimension(nx, nrf) :: r_sam, t_sam, tabs_sam
+        real(8), dimension(nx, nrf) :: tabs_sam
+            !! absolute temperature [K] on the SAM grid
+        real(8), dimension(nx, nrf) :: r_sam
+            !! non-precipitating water mixing ratio [kg/kg] on the SAM grid
+        real(8), dimension(nx, nrf) :: t_sam
+            !! static energy [J/kg] on the SAM grid
         real(8), dimension(nx, nrf) :: qi_sam, qv_sam, qc_sam
-        real(8), dimension(nx, nrf) :: qi0_sam, qv0_sam, qc0_sam
+            !! mixing ratios [kg/kg] on the SAM grid
+        real(8), dimension(nx, nrf) :: qi0_sam, qv0_sam, qc0_sam, tabs0_sam, r0_sam
+            !! Variables at the start of the parameterisation on the SAM grid - used to calculate tendencies
         real(8), dimension(nx, nrf) :: dqi_sam, dqv_sam, dqc_sam, ds_sam
-        real(8), dimension(nx) :: qi_surf, qv_surf, qc_surf, tabs_surf
+            !! CAM variable tendencies calculated on the SAM grid
+        real(8), dimension(nx)      :: qi_surf, qv_surf, qc_surf, tabs_surf
+            !! Surface values
+        real(8) :: y_in(nx)
+            !! Distance of column from equator (proxy for insolation and sfc albedo)
+        real(8), dimension(nx)      :: precsfc_i
+            !! precipitation at surface from one call to parameterisation
 
         integer :: k
 
@@ -242,7 +249,7 @@ contains
         !! coarser than the target (SAM) grid.
 
         !! NOTE: When reading this code remember that pressure DECREASES monotonically
-        !!       with altitude, so comparisons are not intuitive: Pa > Pb => a is below b
+        !!       with altitude, so comparisons are not intuitive: Pa > Pb => a is lower altitude than b
 
         != unit hPa :: p_cam, p_surf_cam
         real(8), dimension(:,:), intent(in) :: p_cam

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -8,7 +8,7 @@ module nn_interface_CAM
 use netcdf
 use nn_convection_flux_mod, only: nn_convection_flux, &
                                   nn_convection_flux_init, nn_convection_flux_finalize, &
-                                  esati, qsati, qsatw, dtqsatw, dtqsati
+                                  esati, rsati, rsatw, dtrsatw, dtrsati
 use SAM_consts_mod, only: nrf, ggr, cp, tbgmax, tbgmin, tprmax, tprmin, &
                           fac_cond, fac_sub, fac_fus, &
                           a_bg, a_pr, an, bn, ap, bp, &
@@ -636,7 +636,7 @@ contains
             !! normalised liquid ice static energy
 
         ! Intermediate variables
-        real(8) :: qsat, om, omn, dtabs, dqsat, lstarn, dlstarn, fff, dfff, rv, r_temp
+        real(8) :: rsat, om, omn, dtabs, drsat, lstarn, dlstarn, fff, dfff, rv, r_temp
 
         nx = size(tabs, 1)
         nz = size(tabs, 2)
@@ -656,18 +656,18 @@ contains
             ! Set saturation vapour based on cloud type
             ! Warm cloud:
             if(tabs1.ge.tbgmax) then
-                qsat = qsatw(tabs1,pres(k))
+                rsat = rsatw(tabs1,pres(k))
             ! Ice cloud:
             elseif(tabs1.le.tbgmin) then
-                qsat = qsati(tabs1,pres(k))
+                rsat = rsati(tabs1,pres(k))
             ! Mixed-phase cloud:
             else
                 om = an*tabs1-bn
-                qsat = om*qsatw(tabs1,pres(k))+(1.-om)*qsati(tabs1,pres(k))
+                rsat = om*rsatw(tabs1,pres(k))+(1.-om)*rsati(tabs1,pres(k))
             endif
 
             !  Test if condensation is possible (humidity is above saturation) and iterate:
-            if(r_temp .gt. qsat) then
+            if(r_temp .gt. rsat) then
                 niter=0
                 dtabs = 100.
                 do while(abs(dtabs).gt.0.01.and.niter.lt.10)
@@ -676,40 +676,40 @@ contains
                         om=1.
                         lstarn=fac_cond
                         dlstarn=0.
-                        qsat=qsatw(tabs1,pres(k))
-                        dqsat=dtqsatw(tabs1,pres(k))
+                        rsat=rsatw(tabs1,pres(k))
+                        drsat=dtrsatw(tabs1,pres(k))
                     ! Ice cloud regime
                     else if(tabs1.le.tbgmin) then
                         om=0.
                         lstarn=fac_sub
                         dlstarn=0.
-                        qsat=qsati(tabs1,pres(k))
-                        dqsat=dtqsati(tabs1,pres(k))
+                        rsat=rsati(tabs1,pres(k))
+                        drsat=dtrsati(tabs1,pres(k))
                     ! Mixed cloud regime
                     else
                         om=an*tabs1-bn
                         lstarn=fac_cond+(1.-om)*fac_fus
                         dlstarn=an
-                        qsat=om*qsatw(tabs1,pres(k))+(1.-om)*qsati(tabs1,pres(k))
-                        dqsat=om*dtqsatw(tabs1,pres(k))+(1.-om)*dtqsati(tabs1,pres(k))
+                        rsat=om*rsatw(tabs1,pres(k))+(1.-om)*rsati(tabs1,pres(k))
+                        drsat=om*dtrsatw(tabs1,pres(k))+(1.-om)*dtrsati(tabs1,pres(k))
                     endif
 
                     ! Update thermodynamics and check for convergence
-                    fff = tabs(i,k)-tabs1+lstarn*(r_temp-qsat)
-                    dfff=dlstarn*(r_temp-qsat)-lstarn*dqsat-1.
+                    fff = tabs(i,k)-tabs1+lstarn*(r_temp-rsat)
+                    dfff=dlstarn*(r_temp-rsat)-lstarn*drsat-1.
                     dtabs=-fff/dfff
                     niter=niter+1
                     tabs1=tabs1+dtabs
                end do
 
                ! Update saturation point and then calculate water and residual vapour content
-               qsat = qsat + dqsat * dtabs
-               qn = max(0., r_temp-qsat)
+               rsat = rsat + drsat * dtabs
+               rn = max(0., r_temp-rsat)
                rv = max(0., r_temp-qn)
 
             ! If condensation not possible qn is 0.0
             else
-              qn = 0.
+              rn = 0.
               rv = r_temp
 
             endif
@@ -721,8 +721,8 @@ contains
             ! Taken from statistics.f90 in SAM assuming dokruegermicro=.false.
             ! Also implements conversion from SAM dry mixing ratios to CAM moist mixing ratios
             omn = omegan(tabs(i,k))
-            qc(i,k) = qn*omn/(1.+rv)
-            qi(i,k) = qn*(1.-omn)/(1.+rv)
+            qc(i,k) = rn*omn/(1.+rv)
+            qi(i,k) = rn*(1.-omn)/(1.+rv)
             qv(i,k) = rv/(1.+rv)
 
         end do

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -557,8 +557,8 @@ contains
             !! Counters
         real(8) :: omn
             !! intermediate omn factor used in variable conversion
-        real(8) :: rv
-            !! intermediate rv to hold dry mixing ratio
+        real(8) :: rv, rc, ri
+            !! intermediate r values to hold dry mixing ratios of vapour, cld, ice
 
         ! ---------------------
         ! Fields from CAM/SAM
@@ -586,13 +586,15 @@ contains
           do i = 1, nx
             ! Calculate dry mixing ratio as required by SAM from moist variables as provided by CAM
             rv = qv(i,k) / (1. - qv(i,k))
-            r(i,k) = rv + qc(i,k)*(1.+rv) + qi(i,k)*(1.+rv)
+            rc = qc(i,k) * (1.+rv)
+            ri = qi(i,k) * (1.+rv)
+            r(i,k) = rv + rc + ri
 
             ! omp  = max(0.,min(1.,(tabs(i,k)-tprmin)*a_pr))
             omn  = max(0.,min(1.,(tabs(i,k)-tbgmin)*a_bg))
             t(i,k) = tabs(i,k) &
                    ! - (fac_cond+(1.-omp)*fac_fus)*qp(i,k) &  ! There is no qp in CAM
-                     - (fac_cond+(1.-omn)*fac_fus)*(qc(i,k)*(1.+rv) + qi(i,k)*(1.+rv)) &
+                     - (fac_cond+(1.-omn)*fac_fus)*(rc + ri) &
                      + gamaz(k)
           end do
         end do

--- a/src/physics/cam/yog_intr.F90
+++ b/src/physics/cam/yog_intr.F90
@@ -198,7 +198,7 @@ subroutine yog_tend(ztodt, state, ptend)
    real(r8), pointer, dimension(:)   :: snow         ! snow
    real(r8), pointer, dimension(:,:) :: cld
 
-   real(r8) :: yog_precsfc(pcols)  ! scattered precip flux at each level
+   real(r8) :: yog_precsfc(ncols)  ! scattered precip flux at each level
 
    lchnk = state%lchnk
    ncol  = state%ncol


### PR DESCRIPTION
This addresses #15 

The variable conversion routines now also include a moist - dry conversion and back.

The moist mixing ratios from CAM are now converted to dry mixing ratios as expected by SAM for use in that code, and then back for calculation of tendencies and return values.