### PR TITLE
Add a conversion back to CAM variables before calling the net.

### DIFF
--- a/src/physics/cam/nn_convection_flux.F90
+++ b/src/physics/cam/nn_convection_flux.F90
@@ -56,7 +56,6 @@ contains
 
 
     subroutine nn_convection_flux(tabs_i, q_i, &
-                                  tabs, &
                                   t, q, &
                                   rho, adz, dz, dtn, &
                                   precsfc)
@@ -71,9 +70,9 @@ contains
         ! ---------------------
         ! Fields from beginning of time step used as NN inputs
         ! ---------------------
-        != unit s :: tabs_i
+        != unit K :: tabs_i
         real(8), intent(in) :: tabs_i(:, :)
-            !! Temperature
+            !! Absolute Temperature
 
         != unit 1 :: q_i
         real(8), intent(in) :: q_i(:, :)
@@ -82,10 +81,6 @@ contains
         ! ---------------------
         ! Other fields from SAM
         ! ---------------------
-        != unit K :: tabs
-        real(8), intent(in) :: tabs(:, :)
-            !! absolute temperature
-        
         != unit (J / kg) :: t
         real(8), intent(inout) :: t(:, :)
             !! Liquid Ice static energy (cp*T + g*z − L(qliq + qice) − Lf*qice)
@@ -206,8 +201,8 @@ contains
             ! if (rf_uses_rh) then
             ! ! If using generalised relative humidity convert non-precip. water content to rel. hum
             !     do k=1,nzm
-            !         omn = omegan(tabs(i,j,k))
-            !         rsat(k) = omn * rsatw(tabs(i,j,k),pres(k)) + (1.-omn) * rsati(tabs(i,j,k),pres(k))
+            !         omn = omegan(tabs_i(i,j,k))
+            !         qsat(k) = omn * qsatw(tabs_i(i,j,k),pres(k)) + (1.-omn) * qsati(tabs_i(i,j,k),pres(k))
             !     end do
             !     features(dim_counter+1:dim_counter+input_ver_dim) = real(q_i(i,j,1:input_ver_dim)/rsat(1:input_ver_dim),4)
             !     dim_counter = dim_counter + input_ver_dim
@@ -291,7 +286,7 @@ contains
 
             ! ensure autoconversion tendency won't reduce q below 0
             do k=1,nrf
-                omp(k) = max(0.,min(1.,(tabs(i,k)-tprmin)*a_pr))
+                omp(k) = max(0.,min(1.,(tabs_i(i,k)-tprmin)*a_pr))
                 fac(k) = (fac_cond + fac_fus * (1.0 - omp(k)))
                 if (q_tend_auto(k) < 0) then
                     q_delta_auto(i,k) = - min(-q_tend_auto(k) * dtn, q(i,k))

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -173,10 +173,6 @@ contains
         ! These are calculated following a conversion of the "new" SAM variables back
         ! CAM-space to reduce numerical errors (e.g. tendency is zero).
         call SAM_var_conversion(t_sam, r_sam, tabs0_sam, qv0_sam, qc0_sam, qi0_sam)
-
-        ! TODO Decide whether the 'reconverted' tabs or the interpolated from CAM tabs
-        ! is best here. Consider also plotting to check.
-        ! tabs0_sam = tabs_sam
         r0_sam = r_sam
 
         !-----------------------------------------------------
@@ -186,9 +182,8 @@ contains
         ! advective, autoconversion (dt = -dq*(latent_heat/cp)),
         ! sedimentation (dt = -dq*(latent_heat/cp)),
         ! radiation rest tendency (multiply by dtn to get dt)
-        call nn_convection_flux(tabs0_sam, r0_sam, &
-                                tabs_sam, &
-                                t_sam, r_sam, &
+        call nn_convection_flux(tabs0_sam(:,1:nrf), r0_sam(:,1:nrf), &
+                                t_sam(:,1:nrf), r_sam(:,1:nrf), &
                                 rho, adz, dz, dtn, &
                                 precsfc_i)
         ! Update precsfc with prec from this timestep

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -166,17 +166,21 @@ contains
         ! Convert CAM Moistures and tabs to SAM q and t
         call  CAM_var_conversion(qv_sam, qc_sam, qi_sam, r_sam, tabs_sam, t_sam)
 
+        !-----------------------------------------------------
+
         ! Store variables on SAM grid at the start of the timestep
         ! for calculating tendencies later
-        qv0_sam = qv_sam
-        qc0_sam = qc_sam
-        qi0_sam = qi_sam
-        tabs0_sam = tabs_sam
+        ! These are calculated following a conversion of the "new" SAM variables back
+        ! CAM-space to reduce numerical errors (e.g. tendency is zero).
+        call SAM_var_conversion(t_sam, r_sam, tabs0_sam, qv0_sam, qc0_sam, qi0_sam)
+
+        ! TODO Decide whether the 'reconverted' tabs or the interpolated from CAM tabs
+        ! is best here. Consider also plotting to check.
+        ! tabs0_sam = tabs_sam
+        r0_sam = r_sam
 
         !-----------------------------------------------------
 
-        tabs0_sam = tabs_sam
-        r0_sam = r_sam
         ! Run the neural net parameterisation
         ! Updates q and t with delta values
         ! advective, autoconversion (dt = -dq*(latent_heat/cp)),
@@ -609,7 +613,7 @@ contains
         ! Fields from SAM/CAM
         ! ---------------------
         != unit K :: tabs, tabs1
-        real(8), intent(inout) :: tabs(:, :)
+        real(8), intent(out) :: tabs(:, :)
             !! absolute temperature
         real(8) :: tabs1
             !! Temporary variable for tabs


### PR DESCRIPTION
Add a conversion back to CAM variables before calling the net in order to reduce numerical error in calculation of deltas.

As discussed in #16 this will reduce numerical inaccuracies that could result from the variable conversion schemes and propagate into the tendency calculation.

Closes #16 