### PR TITLE
Clarity and intent updates.

### DIFF
--- a/src/physics/cam/SAM_consts.F90
+++ b/src/physics/cam/SAM_consts.F90
@@ -83,7 +83,7 @@ module SAM_consts_mod
   ! SAM Grid Variables
   ! ---------------------------
   integer, parameter :: input_ver_dim = 30
-      !! Set to 48 in setparm.f90 of SAM. Same as nz_gl, but trained on a run with 30.
+      !! The number of cells in a SAM atmospheric column on which the neural net was trained
   
   ! Outputs from NN are supplied at lowest 30 half-model levels for sedimentation fluxes,
   ! and at 29 levels for fluxes (as flux at bottom boundary is zero).

--- a/src/physics/cam/SAM_consts.F90
+++ b/src/physics/cam/SAM_consts.F90
@@ -92,7 +92,7 @@ module SAM_consts_mod
   integer, parameter :: nrfq = nrf - 1
       !! number of vertical levels the NN uses when boundary condition is set to 0
 
-  real(8), parameter :: dt_sam = 30.0
+  real(8), parameter :: dt_sam = 24.0
       !! SAM timestep in seconds
 
 !---------------------------------------------------------------------

--- a/src/physics/cam/nn_convection_flux.F90
+++ b/src/physics/cam/nn_convection_flux.F90
@@ -357,7 +357,7 @@ contains
             ! Calculate surface precipitation
             ! Combination of sedimentation at surface, and autoconversion in the column
             ! Apply sedimenting flux at surface to get rho*dq term
-            precsfc(i) = precsfc(i) - min(q_sed_flux(1), 0D0) * irhoadzdz(1) * rho(1) * adz(1) !!  *dtn/dz
+            precsfc(i) = precsfc(i) - q_sed_flux(1) * irhoadzdz(1) * rho(1) * adz(1) !!  *dtn/dz
             ! Loop up column for all autoconverted precipitation
             do k=1,nrf
                 precsfc(i) = precsfc(i) - q_delta_auto(i,k) * rho(k) * adz(k)

--- a/src/physics/cam/nn_convection_flux.F90
+++ b/src/physics/cam/nn_convection_flux.F90
@@ -8,7 +8,7 @@ module nn_convection_flux_mod
 ! Libraries to use
 use nn_cf_net_mod, only: nn_cf_net_init, net_forward, nn_cf_net_finalize
 use SAM_consts_mod, only: fac_cond, fac_fus, tprmin, a_pr, input_ver_dim, &
-                          nrf, nrfq, dt_sam
+                          nrf, nrfq
 
 implicit none
 private

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -3,8 +3,6 @@ module nn_interface_CAM
     !! Reference: https://doi.org/10.1029/2020GL091363
     !! Also see YOG20: https://doi.org/10.1038/s41467-020-17142-3
 
-    ! TODO: Check for redundant variables once refactored (icycle, nstatis, precip etc.)
-
 !---------------------------------------------------------------------
 ! Libraries to use
 use netcdf
@@ -91,13 +89,12 @@ contains
                                       cp_cam, &
                                       dtn, &
                                       nx, nz, &
-                                      nstep, nstatis, icycle, &
                                       precsfc, &
                                       dqi, dqv, dqc, ds)
         !! Interface to the nn_convection parameterisation for the CAM model
 
         real(8), intent(in) :: dtn    ! Seconds
-        integer, intent(in) :: nx, nz, nstep, nstatis, icycle
+        integer, intent(in) :: nx, nz
 
         real(8), intent(in) :: cp_cam
             !! specific heat capacity of dry air from CAM [J/kg/K]
@@ -133,9 +130,7 @@ contains
         integer :: k
 
         ! Initialise precipitation to 0 if required and at start of cycle if subcycling
-        if(mod(nstep-1,nstatis).eq.0 .and. icycle.eq.1) then
-            precsfc(:)=0.
-        end if
+        precsfc(:)=0.
 
         ! distance to the equator
         ! y is a proxy for insolation and surface albedo as both are only a function of |y| in SAM

--- a/src/physics/cam/yog_intr.F90
+++ b/src/physics/cam/yog_intr.F90
@@ -215,7 +215,6 @@ subroutine yog_tend(ztodt, state, ptend)
                                cpair, &
                                ztodt, &
                                ncol, pver, &
-                               1, 1, 1, &
                                yog_precsfc, &
                                ptend%q(:,pver:1:-1,ixcldice), ptend%q(:,pver:1:-1,1), &
                                ptend%q(:,pver:1:-1,ixcldliq), ptend%s(:,pver:1:-1))


### PR DESCRIPTION
Closes #27, #26, and #25 

- [x] Set the SAM timestep to 24s instead of 30s #27 
  - Note that this variable was currently unused in the code. It was kept in case it was needed for subcyling in future.
- [x] Update docstrings on variables to clarify their meaning #27 
- [x] Update constraint on surface precipitation to allow negative sedinemtation #26 
- [x] Remove the subcycling variables associated with SAM. #25 
  - it was discussed that if subcycling were to be implemented it would be using the CLUBB framework rather than an internal to YOG framework.