### PR TITLE
Add number concentration tendencies to YOG

### DIFF
--- a/src/physics/cam/yog_intr.F90
+++ b/src/physics/cam/yog_intr.F90
@@ -195,6 +195,7 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
    integer :: ncol                    ! number of atmospheric columns
 
    real(r8) :: ftem(pcols,pver)       ! Temporary workspace for outfld variables
+   real(r8) :: num_tem                ! Temporary holder for number tendency
 
    logical  :: lq(pcnst)
 
@@ -240,12 +241,26 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
 
    ! Update the number concentration tendencies for liquid and ice species
    ! Values taken to match those in the `clubb_tend_cam()` subroutine
+   ! YOG can produce negative number tendency, but we must ensure it doesn't reduce total
+   ! number concentration below 0.0
    call cnst_get_ind('NUMLIQ', ixnumliq)
    call cnst_get_ind('NUMICE', ixnumice)
    do k = 1, pver
    do i = 1, ncol
-      ptend%q(i,k,ixnumliq) = 3. * max(0.0, ptend%q(i,k,ixcldliq)) / (4.0*3.14* 8.0e-6**3*997.0)
-      ptend%q(i,k,ixnumice) = 3. * max(0.0, ptend%q(i,k,ixcldice)) / (4.0*3.14*25.0e-6**3*500.0)
+      ! Liquid
+      num_tem = 3. * ptend%q(i,k,ixcldliq) / (4.0*3.14* 8.0e-6**3*997.0)
+      if (num_tem .lt. 0) then
+         ptend%q(i,k,ixnumliq) = - min(-num_tem, state%q(i,k,ixnumliq)/ztodt)
+      else
+         ptend%q(i,k,ixnumliq) = num_tem
+      endif
+      ! Ice
+      num_tem = 3. * ptend%q(i,k,ixcldice) / (4.0*3.14*25.0e-6**3*500.0)
+      if (num_tem .lt. 0) then
+         ptend%q(i,k,ixnumice) = - min(-num_tem, state%q(i,k,ixnumice)/ztodt)
+      else
+         ptend%q(i,k,ixnumice) = num_tem
+      endif
    end do
    end do
    call outfld('YOGDNUMLIQ ',ptend%q(1,1,ixnumliq) ,pcols   ,lchnk   )

--- a/src/physics/cam/yog_intr.F90
+++ b/src/physics/cam/yog_intr.F90
@@ -114,11 +114,13 @@ subroutine yog_init()
   integer :: history_budget_histfile_num ! output history file number for budget fields
 
   ! Register fields with the output buffer
-  call addfld ('YOGDT  ',   (/ 'lev' /),  'A', 'K/s','T tendency - Yuval-OGorman moist convection')
-  call addfld ('YOGDQ  ',   (/ 'lev' /),  'A', 'kg/kg/s','Q tendency - Yuval-OGorman moist convection')
-  call addfld ('YOGDICE',   (/ 'lev' /),  'A', 'kg/kg/s','Cloud ice tendency - Yuval-OGorman convection')
-  call addfld ('YOGDLIQ',   (/ 'lev' /),  'A', 'kg/kg/s','Cloud liq tendency - Yuval-OGorman convection')
-  call addfld ('PREC_YOG',  horiz_only ,  'A', 'm/s','Surface preciptation - Yuval-OGorman convection')
+  call addfld ('YOGDT  ',    (/ 'lev' /),  'A', 'K/s','T tendency - Yuval-OGorman moist convection')
+  call addfld ('YOGDQ  ',    (/ 'lev' /),  'A', 'kg/kg/s','Q tendency - Yuval-OGorman moist convection')
+  call addfld ('YOGDICE',    (/ 'lev' /),  'A', 'kg/kg/s','Cloud ice tendency - Yuval-OGorman convection')
+  call addfld ('YOGDLIQ',    (/ 'lev' /),  'A', 'kg/kg/s','Cloud liq tendency - Yuval-OGorman convection')
+  call addfld ('PREC_YOG',   horiz_only ,  'A', 'm/s','Surface preciptation - Yuval-OGorman convection')
+  call addfld ('YOGDNUMLIQ', (/ 'lev' /),  'A', 'N/s','Cloud liq number conc. tendency - Yuval-OGorman convection')
+  call addfld ('YOGDNUMICE', (/ 'lev' /),  'A', 'N/s','Cloud ice number conc. tendency - Yuval-OGorman convection')
   if (masterproc) then
      write(iulog,*)'YOG output fields added to buffer'
   end if
@@ -127,11 +129,13 @@ subroutine yog_init()
                      history_budget_histfile_num_out = history_budget_histfile_num)
 
   if ( history_budget ) then
-     call add_default('YOGDT  ' , history_budget_histfile_num, ' ')
-     call add_default('YOGDQ  ' , history_budget_histfile_num, ' ')
-     call add_default('YOGDICE' , history_budget_histfile_num, ' ')
-     call add_default('YOGDLIQ' , history_budget_histfile_num, ' ')
+     call add_default('YOGDT  ', history_budget_histfile_num, ' ')
+     call add_default('YOGDQ  ', history_budget_histfile_num, ' ')
+     call add_default('YOGDICE', history_budget_histfile_num, ' ')
+     call add_default('YOGDLIQ', history_budget_histfile_num, ' ')
      call add_default('PREC_YOG', history_budget_histfile_num, ' ')
+     call add_default('YOGDNUMLIQ', history_budget_histfile_num, ' ')
+     call add_default('YOGDNUMICE', history_budget_histfile_num, ' ')
   end if
 
   call nn_convection_flux_CAM_init(yog_nn_weights, SAM_sounding)
@@ -234,16 +238,18 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
    ! Note that prec_dp is initialised in the physics buffer and zeroed for deep_scheme='off'
    prec(:ncol) = prec(:ncol) + yog_precsfc(:ncol)
 
-  ! Update the number concentration tendencies for liquid and ice species
-  ! Values taken to match those in the `clubb_tend_cam()` subroutine
-  call cnst_get_ind('NUMLIQ', ixnumliq)
-  call cnst_get_ind('NUMICE', ixnumice)
-  do k = 1, pver
-  do i = 1, ncol
-    ptend%q(i,k,ixnumliq) = 3. * max(0.0, ptend%q(i,k,ixcldliq)) / (4.0*3.14* 8.0e-6**3*997.0)
-    ptend%q(i,k,ixnumice) = 3. * max(0.0, ptend%q(i,k,ixcldice)) / (4.0*3.14*25.0e-6**3*500.0)
-  end do
-  end do
+   ! Update the number concentration tendencies for liquid and ice species
+   ! Values taken to match those in the `clubb_tend_cam()` subroutine
+   call cnst_get_ind('NUMLIQ', ixnumliq)
+   call cnst_get_ind('NUMICE', ixnumice)
+   do k = 1, pver
+   do i = 1, ncol
+      ptend%q(i,k,ixnumliq) = 3. * max(0.0, ptend%q(i,k,ixcldliq)) / (4.0*3.14* 8.0e-6**3*997.0)
+      ptend%q(i,k,ixnumice) = 3. * max(0.0, ptend%q(i,k,ixcldice)) / (4.0*3.14*25.0e-6**3*500.0)
+   end do
+   end do
+   call outfld('YOGDNUMLIQ ',ptend%q(1,1,ixnumliq) ,pcols   ,lchnk   )
+   call outfld('YOGDNUMICE ',ptend%q(1,1,ixnumice) ,pcols   ,lchnk   )
 
 end subroutine yog_tend
 

--- a/src/physics/cam/yog_intr.F90
+++ b/src/physics/cam/yog_intr.F90
@@ -239,32 +239,34 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
    ! Note that prec_dp is initialised in the physics buffer and zeroed for deep_scheme='off'
    prec(:ncol) = prec(:ncol) + yog_precsfc(:ncol)
 
-   ! Update the number concentration tendencies for liquid and ice species for all cells
-   ! Match calculations in the `clubb_tend_cam()` subroutine
-   ! YOG could produce negative number tendency, so we ensure it doesn't reduce total
-   ! number concentration below 0.0 - note that a check on this is also made in physics_update()
-   call cnst_get_ind('NUMLIQ', ixnumliq)
-   call cnst_get_ind('NUMICE', ixnumice)
-   do k = 1, pver
-   do i = 1, ncol
-      ! Liquid
-      num_tem = 3. * ptend%q(i,k,ixcldliq) / (4.0*3.14* 8.0e-6**3*997.0)
-      if (num_tem .lt. 0) then
-         ptend%q(i,k,ixnumliq) = - min(-num_tem, state%q(i,k,ixnumliq)/ztodt)
-      else
-         ptend%q(i,k,ixnumliq) = num_tem
-      endif
-      ! Ice
-      num_tem = 3. * ptend%q(i,k,ixcldice) / (4.0*3.14*25.0e-6**3*500.0)
-      if (num_tem .lt. 0) then
-         ptend%q(i,k,ixnumice) = - min(-num_tem, state%q(i,k,ixnumice)/ztodt)
-      else
-         ptend%q(i,k,ixnumice) = num_tem
-      endif
-   end do
-   end do
-   call outfld('YOGDNUMLIQ ',ptend%q(1,1,ixnumliq) ,pcols   ,lchnk   )
-   call outfld('YOGDNUMICE ',ptend%q(1,1,ixnumice) ,pcols   ,lchnk   )
+   !======== NUMBER CONCENTRATION IS CURRENTLY NOT SET AS IT DETRIMENTALLY IMPACTS THE 
+   !         RESULTS HOWEVER, THE CODE FOR THE CALCULATION IS KEPT BELOW, COMMENTED OUT
+   ! ! Update the number concentration tendencies for liquid and ice species for all cells
+   ! ! Match calculations in the `clubb_tend_cam()` subroutine
+   ! ! YOG could produce negative number tendency, so we ensure it doesn't reduce total
+   ! ! number concentration below 0.0 - note that a check on this is also made in physics_update()
+   ! call cnst_get_ind('NUMLIQ', ixnumliq)
+   ! call cnst_get_ind('NUMICE', ixnumice)
+   ! do k = 1, pver
+   ! do i = 1, ncol
+   !    ! Liquid
+   !    num_tem = 3. * ptend%q(i,k,ixcldliq) / (4.0*3.14* 8.0e-6**3*997.0)
+   !    if (num_tem .lt. 0) then
+   !       ptend%q(i,k,ixnumliq) = - min(-num_tem, state%q(i,k,ixnumliq)/ztodt)
+   !    else
+   !       ptend%q(i,k,ixnumliq) = num_tem
+   !    endif
+   !    ! Ice
+   !    num_tem = 3. * ptend%q(i,k,ixcldice) / (4.0*3.14*25.0e-6**3*500.0)
+   !    if (num_tem .lt. 0) then
+   !       ptend%q(i,k,ixnumice) = - min(-num_tem, state%q(i,k,ixnumice)/ztodt)
+   !    else
+   !       ptend%q(i,k,ixnumice) = num_tem
+   !    endif
+   ! end do
+   ! end do
+   ! call outfld('YOGDNUMLIQ ',ptend%q(1,1,ixnumliq) ,pcols   ,lchnk   )
+   ! call outfld('YOGDNUMICE ',ptend%q(1,1,ixnumice) ,pcols   ,lchnk   )
 
 end subroutine yog_tend
 

--- a/src/physics/cam/yog_intr.F90
+++ b/src/physics/cam/yog_intr.F90
@@ -239,10 +239,10 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
    ! Note that prec_dp is initialised in the physics buffer and zeroed for deep_scheme='off'
    prec(:ncol) = prec(:ncol) + yog_precsfc(:ncol)
 
-   ! Update the number concentration tendencies for liquid and ice species
-   ! Values taken to match those in the `clubb_tend_cam()` subroutine
-   ! YOG can produce negative number tendency, but we must ensure it doesn't reduce total
-   ! number concentration below 0.0
+   ! Update the number concentration tendencies for liquid and ice species for all cells
+   ! Match calculations in the `clubb_tend_cam()` subroutine
+   ! YOG could produce negative number tendency, so we ensure it doesn't reduce total
+   ! number concentration below 0.0 - note that a check on this is also made in physics_update()
    call cnst_get_ind('NUMLIQ', ixnumliq)
    call cnst_get_ind('NUMICE', ixnumice)
    do k = 1, pver

--- a/src/physics/cam/yog_intr.F90
+++ b/src/physics/cam/yog_intr.F90
@@ -183,9 +183,10 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
 
    ! Local variables
 
-   integer :: i
+   integer :: i, k
    integer :: nstep
    integer :: ixcldice, ixcldliq      ! constituent indices for cloud liquid and ice water.
+   integer :: ixnumice, ixnumliq      ! constituent indices for cloud liquid and ice number concentration.
    integer :: lchnk                   ! chunk identifier
    integer :: ncol                    ! number of atmospheric columns
 
@@ -232,6 +233,17 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
    ! Add prec_yog to prec_dp for passing to physpkg and coupler
    ! Note that prec_dp is initialised in the physics buffer and zeroed for deep_scheme='off'
    prec(:ncol) = prec(:ncol) + yog_precsfc(:ncol)
+
+  ! Update the number concentration tendencies for liquid and ice species
+  ! Values taken to match those in the `clubb_tend_cam()` subroutine
+  call cnst_get_ind('NUMLIQ', ixnumliq)
+  call cnst_get_ind('NUMICE', ixnumice)
+  do k = 1, pver
+  do i = 1, ncol
+    ptend%q(i,k,ixnumliq) = 3. * max(0.0, ptend%q(i,k,ixcldliq)) / (4.0*3.14* 8.0e-6**3*997.0)
+    ptend%q(i,k,ixnumice) = 3. * max(0.0, ptend%q(i,k,ixcldice)) / (4.0*3.14*25.0e-6**3*500.0)
+  end do
+  end do
 
 end subroutine yog_tend
 


### PR DESCRIPTION
This PR should close #18 by adding a calculation for number concentration tendency to the YOG code using the updated cloud liquid and ice tendencies.

- The number concentration calculation is taken from the clubb routines.
- Number concentration tendency from YOG is allowed to be negative, but cannot reduce total number concentration below zero.
- Number concentration tendency from YOG is added as an optional output to the statistics files.
- Perform a check to ensure that the tendency will not generate negative number concentration and limit if necessary.

Note this is a reimplementation of #23 that was removed from main when resolving issues with moist-dry conversion