### PR TITLE
Update array sizes used in YOG parameterisation

### DIFF
--- a/src/physics/cam/nn_cf_net.F90
+++ b/src/physics/cam/nn_cf_net.F90
@@ -70,14 +70,14 @@ contains
 
     !-----------------------------------------------------------------
     ! Public Subroutines
-    
+
     subroutine relu(logits)
         !! Applies ReLU to a vector.
 
          real(4), dimension(:), intent(inout)   :: logits
              !! vector to which ReLU will be applied
 
-         where (logits .lt. 0.0)  logits = 0.0
+         where (logits < 0.0)  logits = 0.0
 
     end subroutine relu
 
@@ -85,7 +85,7 @@ contains
     subroutine net_forward(features, logits)
         !! Run forward method of the Neural Net.
 
-        real(4), dimension(:) :: features
+        real(4), dimension(:), intent(inout) :: features
             !! Vector of input features
         real(4), dimension(:), intent(out)  :: logits
             !! Output vector

--- a/src/physics/cam/nn_convection_flux.F90
+++ b/src/physics/cam/nn_convection_flux.F90
@@ -89,7 +89,7 @@ contains
         != unit (J / kg) :: t
         real(8), intent(inout) :: t(:, :)
             !! Liquid Ice static energy (cp*T + g*z − L(qliq + qice) − Lf*qice)
-        
+
         != unit 1 :: q
         real(8), intent(inout) :: q(:, :)
             !! total water
@@ -100,15 +100,15 @@ contains
         != unit (kg / m**3) :: rho
         real(8), intent(in) :: rho(:)
             !! air density at pressure levels
-        
+
         ! != unit mb :: pres
         ! real(8), intent(in) pres(nzm)
         !     !! pressure,mb at scalar levels
-        
+
         != unit 1 :: adz
         real(8), intent(in) :: adz(:)
             !! ratio of the pressure level grid height spacing [m] to dz (lowest dz spacing)
-        
+
         ! ---------------------
         ! Single value parameters from model/grid
         ! ---------------------
@@ -138,8 +138,8 @@ contains
         ! Local Variables
         ! -----------------------------------
         integer  i, k, dim_counter, out_dim_counter
-        integer nx
-            !! Number of x points in a subdomain
+        integer ncol
+            !! Number of columns in a subdomain
         integer nzm
             !! Number of z points in a subdomain - 1
         ! real(8) :: omn
@@ -161,7 +161,7 @@ contains
         real(8),   dimension(nrf) :: t_flux_adv, q_flux_adv, q_tend_auto, &
                                   q_sed_flux, t_rad_rest_tend
 
-        nx = size(tabs_i, 1)
+        ncol = size(tabs_i, 1)
         nzm = size(tabs_i, 2)
 
         ! Check that we have initialised all of the variables.
@@ -174,7 +174,7 @@ contains
         end do
 
         ! The NN operates on atmospheric columns which have been flattened into 2D
-        do i=1,nx
+        do i=1,ncol
             ! Initialize variables
             features = 0.
             dim_counter = 0
@@ -250,21 +250,21 @@ contains
 
             ! total non-precip. water mix. ratio ice-sedimenting flux
             q_sed_flux(1:nrf) = outputs(out_dim_counter+1:out_dim_counter+nrf)
-            
+
             !-----------------------------------------------------
             ! Apply physical constraints and update q and t
 
             ! Non-precip. water content must be >= 0, so ensure advective fluxes
             ! will not reduce it below 0 anywhere
             do k=2,nrf
-                if (q_flux_adv(k).lt.0) then
+                if (q_flux_adv(k) < 0) then
                     ! If flux is negative ensure we don't lose more than is already present
-                    if ( q(i,k).lt.-q_flux_adv(k)* irhoadzdz(k)) then
+                    if ( q(i,k) < -q_flux_adv(k)* irhoadzdz(k)) then
                         q_flux_adv(k) = -q(i,k)/irhoadzdz(k)
                     end if
                 else
                     ! If flux is positive ensure we don't gain more than is in the box below
-                    if (q(i,k-1).lt.q_flux_adv(k)* irhoadzdz(k)) then
+                    if (q(i,k-1) < q_flux_adv(k)* irhoadzdz(k)) then
                         q_flux_adv(k) = q(i,k-1)/irhoadzdz(k)
                     end if
                 end if
@@ -280,7 +280,7 @@ contains
             q_delta_adv(i,nrf) = - (0.0 - q_flux_adv(nrf)) * irhoadzdz(nrf)
             ! q must be >= 0 so ensure delta won't reduce it below zero
             do k=1,nrf
-                if (q(i,k) .lt. -q_delta_adv(i,k)) then
+                if (q(i,k) < -q_delta_adv(i,k)) then
                     q_delta_adv(i,k) = -q(i,k)
                 end if
             end do
@@ -293,7 +293,7 @@ contains
             do k=1,nrf
                 omp(k) = max(0.,min(1.,(tabs(i,k)-tprmin)*a_pr))
                 fac(k) = (fac_cond + fac_fus * (1.0 - omp(k)))
-                if (q_tend_auto(k).lt.0) then
+                if (q_tend_auto(k) < 0) then
                     q_delta_auto(i,k) = - min(-q_tend_auto(k) * dtn, q(i,k))
                 else
                     q_delta_auto(i,k) = q_tend_auto(k) * dtn
@@ -307,14 +307,14 @@ contains
 
             ! Ensure sedimenting ice will not reduce q below zero anywhere
             do k=2,nrf
-                if (q_sed_flux(k).lt.0) then
+                if (q_sed_flux(k) < 0) then
                     ! If flux is negative ensure we don't lose more than is already present
-                    if ( q(i,k).lt.-q_sed_flux(k)* irhoadzdz(k)) then
+                    if ( q(i,k) < -q_sed_flux(k)* irhoadzdz(k)) then
                         q_sed_flux(k) = -q(i,k)/irhoadzdz(k)
                     end if
                 else
                     ! If flux is positive ensure we don't gain more than is in the box below
-                    if (q(i,k-1).lt.q_sed_flux(k)* irhoadzdz(k)) then
+                    if (q(i,k-1) < q_sed_flux(k)* irhoadzdz(k)) then
                         q_sed_flux(k) = q(i,k-1)/irhoadzdz(k)
                     end if
                 end if
@@ -328,7 +328,7 @@ contains
             q_delta_sed(i,nrf) = - (0.0 - q_sed_flux(nrf)) * irhoadzdz(nrf)
             ! q must be >= 0 so ensure delta won't reduce it below zero
             do k=1,nrf
-                if (q_delta_sed(i,k).lt.0) then
+                if (q_delta_sed(i,k) < 0) then
                     q_delta_sed(i,k) = min(-q_delta_sed(i,k), q(i,k))
                     q_delta_sed(i,k) = -q_delta_sed(i,k)
                 end if
@@ -350,7 +350,7 @@ contains
                 precsfc(i) = precsfc(i) - q_delta_auto(i,k) * rho(k) * adz(k)
             end do
             precsfc(i) = precsfc(i) * dz
-            
+
             ! As a final check enforce q must be >= 0.0
             do k = 1,nrf
                 q(i,k) = max(0.,q(i,k))
@@ -369,9 +369,9 @@ contains
 
     end subroutine nn_convection_flux_finalize
 
-    
+
     !-----------------------------------------------------------------
-    
+
     subroutine error_mesg (message)
       character(len=*), intent(in) :: message
           !! message to be written to output   (character string)
@@ -398,9 +398,8 @@ contains
 
     != unit mb :: esatw
     real(8) function esatw(t)
-      implicit none
       != unit K :: t
-      real(8) :: t  ! temperature (K)
+      real(8), intent(in) :: t  ! temperature (K)
 
       != unit :: a0
       != unit :: mb / k :: a1, a2, a3, a4, a5, a6, a7, a8
@@ -422,9 +421,8 @@ contains
 
     != unit 1 :: rsatw
     real(8) function rsatw(t,p)
-      implicit none
       != unit K :: t
-      real(8) :: t  ! temperature
+      real(8), intent(in) :: t  ! temperature
 
       != unit mb :: p, esat
       real(8) :: p  ! pressure
@@ -436,8 +434,7 @@ contains
 
 
     real(8) function dtesatw(t)
-      implicit none
-      real(8) :: t  ! temperature (K)
+      real(8), intent(in) :: t  ! temperature (K)
       real(8) :: a0,a1,a2,a3,a4,a5,a6,a7,a8
       data a0,a1,a2,a3,a4,a5,a6,a7,a8 /&
                 0.443956472, 0.285976452e-1, 0.794747212e-3, &
@@ -450,17 +447,15 @@ contains
 
 
     real(8) function dtrsatw(t,p)
-      implicit none
-      real(8) :: t  ! temperature (K)
-      real(8) :: p  ! pressure    (mb)
+      real(8), intent(in) :: t  ! temperature (K)
+      real(8), intent(in) :: p  ! pressure    (mb)
       dtrsatw=0.622*dtesatw(t)/p
     end function dtrsatw
 
 
     real(8) function esati(t)
-      implicit none
       != unit K :: t
-      real(8) :: t  ! temperature
+      real(8), intent(in) :: t  ! temperature
       real(8) :: a0,a1,a2,a3,a4,a5,a6,a7,a8
       data a0,a1,a2,a3,a4,a5,a6,a7,a8 /&
               6.11147274, 0.503160820, 0.188439774e-1, &
@@ -474,12 +469,11 @@ contains
 
     != unit 1 :: rsati
     real(8) function rsati(t,p)
-      implicit none
       != unit t :: K
-      real(8) :: t  ! temperature
+      real(8), intent(in) :: t  ! temperature
 
       != unit mb :: p
-      real(8) :: p  ! pressure
+      real(8), intent(in) :: p  ! pressure
 
       != unit mb :: esat
       real(8) :: esat
@@ -489,8 +483,7 @@ contains
 
 
     real(8) function dtesati(t)
-      implicit none
-      real(8) :: t  ! temperature (K)
+      real(8), intent(in) :: t  ! temperature (K)
       real(8) :: a0,a1,a2,a3,a4,a5,a6,a7,a8
       data a0,a1,a2,a3,a4,a5,a6,a7,a8 / &
               0.503223089, 0.377174432e-1,0.126710138e-2, &
@@ -504,9 +497,8 @@ contains
 
 
     real(8) function dtrsati(t,p)
-      implicit none
-      real(8) :: t  ! temperature (K)
-      real(8) :: p  ! pressure    (mb)
+      real(8), intent(in) :: t  ! temperature (K)
+      real(8), intent(in) :: p  ! pressure    (mb)
       dtrsati = 0.622 * dtesati(t) / p
     end function dtrsati
 

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -76,13 +76,13 @@ contains
                                       tabs_cam, qv_cam, qc_cam, qi_cam, &
                                       cp_cam, &
                                       dtn, &
-                                      nx, nz, &
+                                      ncol, &
                                       precsfc, &
                                       dqi, dqv, dqc, ds)
         !! Interface to the nn_convection parameterisation for the CAM model
 
         real(8), intent(in) :: dtn    ! Seconds
-        integer, intent(in) :: nx, nz
+        integer, intent(in) :: ncol   ! Number of columns 'used' in each array
 
         real(8), intent(in) :: cp_cam
             !! specific heat capacity of dry air from CAM [J/kg/K]
@@ -97,29 +97,29 @@ contains
         real(8), dimension(:,:), intent(in) :: qv_cam, qc_cam, qi_cam
             !! moisture content [kg/kg] from the CAM model
 
-        real(8), dimension(nx, nz), intent(out) :: dqi, dqv, dqc, ds
+        real(8), dimension(:, :), intent(out) :: dqi, dqv, dqc, ds
             !! Output tendencies - CAM variables on the CAM grid
         real(8), dimension(:), intent(out) :: precsfc
             !! Output surface precipitation in CAM
 
         ! Local input variables on the SAM grid
-        real(8), dimension(nx, nrf) :: tabs_sam
+        real(8), dimension(ncol, nrf) :: tabs_sam
             !! absolute temperature [K] on the SAM grid
-        real(8), dimension(nx, nrf) :: r_sam
+        real(8), dimension(ncol, nrf) :: r_sam
             !! non-precipitating water mixing ratio [kg/kg] on the SAM grid
-        real(8), dimension(nx, nrf) :: t_sam
+        real(8), dimension(ncol, nrf) :: t_sam
             !! static energy [J/kg] on the SAM grid
-        real(8), dimension(nx, nrf) :: qi_sam, qv_sam, qc_sam
+        real(8), dimension(ncol, nrf) :: qi_sam, qv_sam, qc_sam
             !! mixing ratios [kg/kg] on the SAM grid
-        real(8), dimension(nx, nrf) :: qi0_sam, qv0_sam, qc0_sam, tabs0_sam, r0_sam
+        real(8), dimension(ncol, nrf) :: qi0_sam, qv0_sam, qc0_sam, tabs0_sam, r0_sam
             !! Variables at the start of the parameterisation on the SAM grid - used to calculate tendencies
-        real(8), dimension(nx, nrf) :: dqi_sam, dqv_sam, dqc_sam, ds_sam
+        real(8), dimension(ncol, nrf) :: dqi_sam, dqv_sam, dqc_sam, ds_sam
             !! CAM variable tendencies calculated on the SAM grid
-        real(8), dimension(nx)      :: qi_surf, qv_surf, qc_surf, tabs_surf
+        real(8), dimension(ncol)      :: qi_surf, qv_surf, qc_surf, tabs_surf
             !! Surface values
-        real(8) :: y_in(nx)
+        real(8) :: y_in(ncol)
             !! Distance of column from equator (proxy for insolation and sfc albedo)
-        real(8), dimension(nx)      :: precsfc_i
+        real(8), dimension(ncol)      :: precsfc_i
             !! precipitation at surface from one call to parameterisation
 
         integer :: k
@@ -132,34 +132,34 @@ contains
         ! Interpolate CAM variables to the SAM pressure levels
         ! TODO Interpolate all variables in one call
         ! Set surface values
-        call extrapolate_to_surface(pres_cam, qi_cam, pres_sfc_cam, qi_surf)
+        call extrapolate_to_surface(pres_cam(1:ncol, :), qi_cam(1:ncol, :), pres_sfc_cam(1:ncol), qi_surf)
         where (qi_surf>=0)
             qi_surf = qi_surf
         elsewhere
             qi_surf = 0
         end where
-        call extrapolate_to_surface(pres_cam, qc_cam, pres_sfc_cam, qc_surf)
+        call extrapolate_to_surface(pres_cam(1:ncol, :), qc_cam(1:ncol, :), pres_sfc_cam(1:ncol), qc_surf)
         where (qc_surf>=0)
             qc_surf = qc_surf
         elsewhere
             qc_surf = 0
         end where
-        call extrapolate_to_surface(pres_cam, qv_cam, pres_sfc_cam, qv_surf)
+        call extrapolate_to_surface(pres_cam(1:ncol, :), qv_cam(1:ncol, :), pres_sfc_cam(1:ncol), qv_surf)
         where (qv_surf>=0)
             qv_surf = qv_surf
         elsewhere
             qv_surf = 0
         end where
-        call extrapolate_to_surface(pres_cam, tabs_cam, pres_sfc_cam, tabs_surf)
+        call extrapolate_to_surface(pres_cam(1:ncol, :), tabs_cam(1:ncol, :), pres_sfc_cam(1:ncol), tabs_surf)
 
-        call interp_to_sam(pres_cam, pres_sfc_cam, &
-                           tabs_cam, tabs_sam, tabs_surf)
-        call interp_to_sam(pres_cam, pres_sfc_cam, &
-                           qi_cam, qi_sam, qi_surf)
-        call interp_to_sam(pres_cam, pres_sfc_cam, &
-                           qc_cam, qc_sam, qc_surf)
-        call interp_to_sam(pres_cam, pres_sfc_cam, &
-                           qv_cam, qv_sam, qv_surf)
+        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
+                           tabs_cam(1:ncol, :), tabs_sam, tabs_surf)
+        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
+                           qi_cam(1:ncol, :), qi_sam, qi_surf)
+        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
+                           qc_cam(1:ncol, :), qc_sam, qc_surf)
+        call interp_to_sam(pres_cam(1:ncol, :), pres_sfc_cam(1:ncol), &
+                           qv_cam(1:ncol, :), qv_sam, qv_surf)
 
         !-----------------------------------------------------
         
@@ -182,9 +182,9 @@ contains
         ! advective, autoconversion (dt = -dq*(latent_heat/cp)),
         ! sedimentation (dt = -dq*(latent_heat/cp)),
         ! radiation rest tendency (multiply by dtn to get dt)
-        call nn_convection_flux(tabs0_sam(:,1:nrf), r0_sam(:,1:nrf), &
-                                tabs_sam(:,1:nrf), &
-                                t_sam(:,1:nrf), r_sam(:,1:nrf), &
+        call nn_convection_flux(tabs0_sam, r0_sam, &
+                                tabs_sam, &
+                                t_sam, r_sam, &
                                 rho, adz, dz, dtn, &
                                 precsfc_i)
         ! Update precsfc with prec from this timestep
@@ -213,10 +213,10 @@ contains
         ! Interpolate SAM variables to the CAM pressure levels
         ! setting tendencies above the SAM grid to 0.0
         ! TODO Interpolate all variables in one call
-        call interp_to_cam(pres_cam, pres_int_cam, pres_sfc_cam, dqv_sam, dqv)
-        call interp_to_cam(pres_cam, pres_int_cam, pres_sfc_cam, dqc_sam, dqc)
-        call interp_to_cam(pres_cam, pres_int_cam, pres_sfc_cam, dqi_sam, dqi)
-        call interp_to_cam(pres_cam, pres_int_cam, pres_sfc_cam, ds_sam, ds)
+        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), dqv_sam, dqv(1:ncol, :))
+        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), dqc_sam, dqc(1:ncol, :))
+        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), dqi_sam, dqi(1:ncol, :))
+        call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), ds_sam,  ds(1:ncol, :))
 
     end subroutine nn_convection_flux_CAM
 
@@ -455,7 +455,6 @@ contains
         real(8), dimension(:), intent(out) :: var_surf_cam
             !! variable from CAM grid to be interpolated from
 
-        integer :: i, k
         real(8) :: gdt(size(var_surf_cam))
 
         gdt(:) = (var_cam(:,2) - var_cam(:,1)) / (p_cam(:,2) - p_cam(:,1))
@@ -545,7 +544,7 @@ contains
         !!          Using a grid that does not match the SAM grid for input/output
         !!          data will produce unphysical values.
 
-        integer :: nx, nz
+        integer :: ncol, nz
             !! array sizes
         integer :: i, k
             !! Counters
@@ -573,11 +572,11 @@ contains
             !! Absolute temperature from CAM
 
 
-        nx = size(r, 1)
+        ncol = size(r, 1)
         nz = size(r, 2)
 
         do k = 1, nz
-          do i = 1, nx
+          do i = 1, ncol
             ! Calculate dry mixing ratio as required by SAM from moist variables as provided by CAM
             rv = qv(i,k) / (1. - qv(i,k))
             rc = qc(i,k) * (1.+rv)
@@ -601,7 +600,7 @@ contains
         !! t is normalised liquid ice static energy, r is a dry mixing ratio
         !! tabs is absolute temperature, q is cloud vapor/liquid/ice,
 
-        integer :: nx, nz
+        integer :: ncol, nz
             !! array sizes
         integer :: i, k, niter
             !! Counters
@@ -632,13 +631,13 @@ contains
         ! Intermediate variables
         real(8) :: rsat, om, omn, dtabs, drsat, lstarn, dlstarn, fff, dfff, rn, rv, r_temp
 
-        nx = size(tabs, 1)
+        ncol = size(tabs, 1)
         nz = size(tabs, 2)
 
         ! Loop over all cells and iterate until equilibrium of condensed species is achieved.
         ! This code is adapted from cloud.f90 in SAM
         do k = 1, nz
-        do i = 1, nx
+        do i = 1, ncol
         
             ! Enforce r >= 0.0
             r_temp=max(0.,r(i,k))

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -128,7 +128,7 @@ contains
         precsfc(:)=0.
 
         !-----------------------------------------------------
-        
+
         ! Interpolate CAM variables to the SAM pressure levels
         ! TODO Interpolate all variables in one call
         ! Set surface values
@@ -162,7 +162,7 @@ contains
                            qv_cam(1:ncol, :), qv_sam, qv_surf)
 
         !-----------------------------------------------------
-        
+
         ! Convert CAM Moistures and tabs to SAM q and t
         call  CAM_var_conversion(qv_sam, qc_sam, qi_sam, r_sam, tabs_sam, t_sam)
 
@@ -191,7 +191,7 @@ contains
         precsfc = precsfc + precsfc_i
 
         !-----------------------------------------------------
-        
+
         ! Formulate the output variables to CAM as required.
         call SAM_var_conversion(t_sam, r_sam, tabs_sam, qv_sam, qc_sam, qi_sam)
         ! Convert precipitation from kg/m^2 to m by dividing by density (1000)
@@ -232,7 +232,7 @@ contains
 
     !-----------------------------------------------------------------
     ! Private Subroutines
-    
+
     subroutine interp_to_sam(p_cam, p_surf_cam, var_cam, var_sam, var_cam_surface)
         !! Interpolate from the CAM pressure grid to the SAM pressure grid.
         !! Uses linear interpolation between nearest grid points on domain (CAM) grid.
@@ -534,7 +534,7 @@ contains
 
 
     subroutine CAM_var_conversion(qv, qc, qi, r, tabs, t)
-        !! Convert CAM moist mixing ratios for species qv, qc, qi to 
+        !! Convert CAM moist mixing ratios for species qv, qc, qi to
         !! dry mixing ratio r to used by SAM parameterisation
         !! q is total water qv/c/i is cloud vapor/liquid/ice
         !! Convert CAM absolute temperature to moist static energy t used by SAM
@@ -593,7 +593,7 @@ contains
         end do
 
     end subroutine CAM_var_conversion
-    
+
 
     subroutine SAM_var_conversion(t, r, tabs, qv, qc, qi)
         !! Convert SAM t and r to tabs, qv, qc, qi used by CAM
@@ -638,7 +638,7 @@ contains
         ! This code is adapted from cloud.f90 in SAM
         do k = 1, nz
         do i = 1, ncol
-        
+
             ! Enforce r >= 0.0
             r_temp=max(0.,r(i,k))
 
@@ -648,10 +648,10 @@ contains
 
             ! Set saturation vapour based on cloud type
             ! Warm cloud:
-            if(tabs1.ge.tbgmax) then
+            if(tabs1 >= tbgmax) then
                 rsat = rsatw(tabs1,pres(k))
             ! Ice cloud:
-            elseif(tabs1.le.tbgmin) then
+            elseif(tabs1 <= tbgmin) then
                 rsat = rsati(tabs1,pres(k))
             ! Mixed-phase cloud:
             else
@@ -660,19 +660,19 @@ contains
             endif
 
             !  Test if condensation is possible (humidity is above saturation) and iterate:
-            if(r_temp .gt. rsat) then
+            if(r_temp > rsat) then
                 niter=0
                 dtabs = 100.
-                do while(abs(dtabs).gt.0.01.and.niter.lt.10)
+                do while(abs(dtabs) > 0.01 .and. niter < 10)
                     ! Warm cloud regime
-                    if(tabs1.ge.tbgmax) then
+                    if(tabs1 >= tbgmax) then
                         om=1.
                         lstarn=fac_cond
                         dlstarn=0.
                         rsat=rsatw(tabs1,pres(k))
                         drsat=dtrsatw(tabs1,pres(k))
                     ! Ice cloud regime
-                    else if(tabs1.le.tbgmin) then
+                    else if(tabs1 <= tbgmin) then
                         om=0.
                         lstarn=fac_sub
                         dlstarn=0.

--- a/src/physics/cam/yog_intr.F90
+++ b/src/physics/cam/yog_intr.F90
@@ -9,7 +9,7 @@ module yog_intr
 ! January 2024
 !---------------------------------------------------------------------------------
    use shr_kind_mod, only: r8=>shr_kind_r8
-   use physconst,    only: cpair                              
+   use physconst,    only: cpair
    use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
    use cam_abortutils,   only: endrun
    use physconst,        only: pi
@@ -17,7 +17,7 @@ module yog_intr
    use perf_mod
    use cam_logfile,  only: iulog
    use constituents, only: cnst_add
-   
+
    implicit none
    private
    save
@@ -42,15 +42,15 @@ contains
 
 ! There is currently no need for a yog_register as nothing to add to the physics buffer
 ! subroutine yog_register
-! 
+!
 ! !----------------------------------------
 ! ! Purpose: register fields with the physics buffer
 ! !----------------------------------------
-! 
+!
 !   use physics_buffer, only : pbuf_add_field, dtype_r8, dtype_i4
-! 
+!
 !   implicit none
-! 
+!
 ! end subroutine yog_register
 
 !=========================================================================================
@@ -103,11 +103,9 @@ subroutine yog_init()
 
   use cam_history,    only: addfld, add_default, horiz_only
   use nn_interface_CAM,   only: nn_convection_flux_CAM_init
-  
+
   use spmd_utils,     only: masterproc
   use phys_control,   only: phys_getopts
-
-  implicit none
 
   integer istat
   logical :: history_budget ! output tendencies and state variables for
@@ -154,8 +152,6 @@ subroutine yog_final()
 !----------------------------------------
 
   use nn_interface_CAM,   only: nn_convection_flux_CAM_finalize
-  
-  implicit none
 
   call nn_convection_flux_CAM_finalize()
 
@@ -209,13 +205,13 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
    ! Note that prec_dp is initialised in the physics buffer and zeroed for deep_scheme='off'
    prec_dp_idx     = pbuf_get_index('PREC_DP')
    call pbuf_get_field(pbuf, prec_dp_idx,     prec )
-   
+
    call cnst_get_ind('CLDLIQ', ixcldliq)
    call cnst_get_ind('CLDICE', ixcldice)
 
    lq(:) = .true.
    call physics_ptend_init(ptend, state%psetcols, 'yogNN', ls=.true., lq=lq(:))! initialize ptend type for YOG
- 
+
    call nn_convection_flux_CAM(state%pmid(:,pver:1:-1), state%pint(:,pverp:1:-1), state%ps, &
                                state%t(:,pver:1:-1), state%q(:,pver:1:-1,1), &
                                state%q(:,pver:1:-1,ixcldliq), state%q(:,pver:1:-1,ixcldice), &
@@ -225,7 +221,7 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
                                yog_precsfc, &
                                ptend%q(:,pver:1:-1,ixcldice), ptend%q(:,pver:1:-1,1), &
                                ptend%q(:,pver:1:-1,ixcldliq), ptend%s(:,pver:1:-1))
- 
+
    ftem(:ncol,:pver) = ptend%s(:ncol,:pver)/cpair
    call outfld('YOGDT   ',ftem               ,pcols   ,lchnk   )
    call outfld('YOGDQ   ',ptend%q(1,1,1) ,pcols   ,lchnk   )

--- a/src/physics/cam/yog_intr.F90
+++ b/src/physics/cam/yog_intr.F90
@@ -221,7 +221,7 @@ subroutine yog_tend(ztodt, state, ptend, pbuf)
                                state%q(:,pver:1:-1,ixcldliq), state%q(:,pver:1:-1,ixcldice), &
                                cpair, &
                                ztodt, &
-                               ncol, pver, &
+                               ncol, &
                                yog_precsfc, &
                                ptend%q(:,pver:1:-1,ixcldice), ptend%q(:,pver:1:-1,1), &
                                ptend%q(:,pver:1:-1,ixcldliq), ptend%s(:,pver:1:-1))


### PR DESCRIPTION
My resolve #47 

Due to the way CAM uses part-full chunks to pass arrays (`ncol` <= `pcol`) the assumed sizes in YOG may not be consistent with sizes passed in from a cam state variable.

This has been gone through with some checks made.

- [x] Check this still runs OK in the TOGA II
- [x] Check if this improves the aquaplanet code