### PR TITLE
Fix name label of energy checker from yog.

### DIFF
--- a/src/physics/cam/physpkg.F90
+++ b/src/physics/cam/physpkg.F90
@@ -1976,7 +1976,7 @@ contains
         call t_stopf('yog_nn')
 
         flx_cnd(:ncol) = prec_dp(:ncol)
-        call check_energy_chng(state, tend, "chkengyfix", nstep, ztodt, zero, flx_cnd, zero, flx_heat)
+        call check_energy_chng(state, tend, "yog_nn", nstep, ztodt, zero, flx_cnd, zero, flx_heat)
     end if
 
     !


### PR DESCRIPTION
As raised by @paogorman in #34 we should relabel the energy checker following YOG.

This is a patch for this and will help towards #34 