### PR TITLE
Implement energy and water checker for YOG

### DIFF
--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -75,18 +75,19 @@ contains
     end subroutine nn_convection_flux_CAM_init
 
     subroutine yog_conservation_check(p_int, t, qv, qc, qi, & 
-            ncol)
+            ncol, nver)
 
         real(8), intent(in) :: p_int(:,:)
         real(8), intent(in) :: t(:,:)
         real(8), intent(in) :: qv(:,:), qc(:,:), qi(:, :)
-        real(8) :: pdel(ncol, pver-1)
+        real(8) :: pdel(ncol, nver-1)
         real(8) :: se(ncol)       ! sum energy
         real(8) :: sw(ncol)       ! sum water
         real(8) :: wv(ncol), wl(ncol), wi(ncol)
 
 !        integer, intent(in) :: lchnk                 ! chunk identifier
         integer, intent(in) :: ncol                  ! number of atmospheric columns
+        integer, intent(in) :: nver                  ! number of vertical levels
         integer  i,k                                 ! column, level indices
 
         se = 0.0
@@ -95,10 +96,10 @@ contains
         wi = 0.0
         sw = 0.0
 
-        pdel = p_int(:, :pver-1) - p_int(:, 2:pver)
+        pdel = p_int(:, :nver-1) - p_int(:, 2:nver)
 
         do i = 1, ncol
-          do k = 1, pver-1
+          do k = 1, nver-1
             se(i) = se(i) + t(i,k) *cpair*pdel(i,k)/gravit
             wv(i) = wv(i) + qv(i,k)      *pdel(i,k)/gravit
             wl(i) = wl(i) + qc(i,k)      *pdel(i,k)/gravit
@@ -170,7 +171,7 @@ contains
         precsfc(:)=0.
         !-----------------------------------------------------
         write(iulog, *), "Before conversion:"
-        call yog_conservation_check(pres_int_cam, tabs_cam, qv_cam, qc_cam, qi_cam, ncol)
+        call yog_conservation_check(pres_int_cam, tabs_cam, qv_cam, qc_cam, qi_cam, ncol, pver)
         !-----------------------------------------------------
 
         ! Interpolate CAM variables to the SAM pressure levels
@@ -248,7 +249,7 @@ contains
                 presi_col(i, :) = presi(:)
         end do
         
-        call yog_conservation_check(presi_col, tabs_sam, qv_sam, qc_sam, qi_sam, ncol)
+        call yog_conservation_check(presi_col, tabs_sam, qv_sam, qc_sam, qi_sam, ncol, nz_sam)
         !-----------------------------------------------------
 
         ! Convert back into CAM variable tendencies (diff div by dtn) on SAM grid

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -167,6 +167,14 @@ contains
         real(8) :: presi_col(ncol, nz_sam)
             !! presi repeated ncol times along one dimension, for energy and water checker    
 
+
+        ! Variables for the energy checker calculations at the end of the code
+        real(8), dimension(:,:), allocatable :: tabs_cam_out
+            !! absolute temperature [K] to the CAM model
+        real(8), dimension(:,:), allocatable :: qv_cam_out, qc_cam_out, qi_cam_out
+            !! moisture content [kg/kg] to the CAM model
+        integer :: ncol_chnk, nver_chnk
+
         integer :: i,k
 
         ! Initialise precipitation to 0 if required and at start of cycle if subcycling
@@ -245,7 +253,7 @@ contains
         precsfc = precsfc * 1.0D-3
 
         !-----------------------------------------------------
-        write(iulog, *), "After conversion:"
+        write(iulog, *), "After YOG NN:"
         !!presi has just one dimension, so we need to repeat it ncol times to get the required input for the checker.
         !!Also, convert from hPa to Pa
         do i = 1, ncol
@@ -273,6 +281,32 @@ contains
         call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), dqc_sam, dqc(1:ncol, :))
         call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), dqi_sam, dqi(1:ncol, :))
         call interp_to_cam(pres_cam(1:ncol, :), pres_int_cam(1:ncol, :), pres_sfc_cam(1:ncol), ds_sam,  ds(1:ncol, :))
+
+        !-----------------------------------------------------
+        ! For purposes of investigating energy conservation apply the tendencies on the
+        ! CAM grid to the CAM inputs, and apply the Marion conservation checker to see
+        ! if values are consistent with the inputs before the parameterisation.
+        ncol_chnk = size(tabs_cam, 1)
+        nver_chnk = size(tabs_cam, 2)
+        allocate(tabs_cam_out(ncol_chnk,nver_chnk))
+        allocate(qv_cam_out(ncol_chnk,nver_chnk))
+        allocate(qc_cam_out(ncol_chnk,nver_chnk))
+        allocate(qi_cam_out(ncol_chnk,nver_chnk))
+
+        tabs_cam_out = tabs_cam + dtn * ds / cp_cam
+        qv_cam_out = qv_cam + dtn * dqv
+        qc_cam_out = qc_cam + dtn * dqc
+        qi_cam_out = qi_cam + dtn * dqi
+
+        write(iulog, *), "After conversion back:"
+        call yog_conservation_check(pres_int_cam, tabs_cam_out, qv_cam_out, qc_cam_out, qi_cam_out, ncol, pver)
+
+        deallocate(tabs_cam_out)
+        deallocate(qv_cam_out)
+        deallocate(qc_cam_out)
+        deallocate(qi_cam_out)
+
+
 
     end subroutine nn_convection_flux_CAM
 

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -161,10 +161,10 @@ contains
             !! Distance of column from equator (proxy for insolation and sfc albedo)
         real(8), dimension(ncol)      :: precsfc_i
             !! precipitation at surface from one call to parameterisation
-        real(8) :: presi_col(ncol, n_sam_lev)
+        real(8) :: presi_col(ncol, nz_sam)
             !! presi repeated ncol times along one dimension, for energy and water checker    
 
-        integer :: k
+        integer :: i,k
 
         ! Initialise precipitation to 0 if required and at start of cycle if subcycling
         precsfc(:)=0.

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -241,7 +241,8 @@ contains
 
         !-----------------------------------------------------
         write(iulog, *), "After conversion:"
-        call yog_conservation_check(presi, tabs_sam, qv_sam, qc_sam, qi_sam, ncol)
+        !!presi has just one dimension
+        !!call yog_conservation_check(presi, tabs_sam, qv_sam, qc_sam, qi_sam, ncol)
         !-----------------------------------------------------
 
         ! Convert back into CAM variable tendencies (diff div by dtn) on SAM grid

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -246,9 +246,10 @@ contains
 
         !-----------------------------------------------------
         write(iulog, *), "After conversion:"
-        !!presi has just one dimension, so we need to repeat it ncol times to get the required input for the checker
+        !!presi has just one dimension, so we need to repeat it ncol times to get the required input for the checker.
+        !!Also, convert from hPa to Pa
         do i = 1, ncol
-                presi_col(i, :) = presi(:)
+                presi_col(i, :) = presi(:)*100.0
         end do
         
         call yog_conservation_check(presi_col, tabs_sam, qv_sam, qc_sam, qi_sam, ncol, nrf)

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -74,7 +74,7 @@ contains
 
     end subroutine nn_convection_flux_CAM_init
 
-    subroutine yog_conservation_check(p_int, t, qv, qc, qi, & 
+    subroutine yog_conservation_check(p_int, t, qv, qc, qi, prec, &
             ncol, nver)
     ! Use this function to check the energy and water conversation by outputting the
     ! respective sums.  
@@ -82,6 +82,7 @@ contains
         real(8), intent(in) :: p_int(:,:)  ! pressure on grid
         real(8), intent(in) :: t(:,:) ! temperature
         real(8), intent(in) :: qv(:,:), qc(:,:), qi(:, :) ! moisture components: water vapor, cloud water, cloud ice
+        real(8), intent(in) :: prec(:)  !! precipitation that has come out of the column
         real(8) :: pdel(ncol, nver-1)  ! pressure in grid cell
         real(8) :: se(ncol)       ! sum of energy
         real(8) :: sw(ncol)       ! sum of water
@@ -112,6 +113,7 @@ contains
 
         write(iulog, *), "Energy sum: ", se
         write(iulog, *), "Water sum: ", sw
+        write(iulog, *), "Water + prec: ", sw + prec
 
     end subroutine yog_conservation_check
 
@@ -171,6 +173,8 @@ contains
         ! Variables for the energy checker calculations at the end of the code
         real(8), dimension(:,:), allocatable :: tabs_cam_out
             !! absolute temperature [K] to the CAM model
+        real(8), dimension(:), allocatable :: prec_cam_out
+            !! precipitation to the CAM model
         real(8), dimension(:,:), allocatable :: qv_cam_out, qc_cam_out, qi_cam_out
             !! moisture content [kg/kg] to the CAM model
         integer :: ncol_chnk, nver_chnk
@@ -181,7 +185,7 @@ contains
         precsfc(:)=0.
         !-----------------------------------------------------
         write(iulog, *), "Before conversion:"
-        call yog_conservation_check(pres_int_cam, tabs_cam, qv_cam, qc_cam, qi_cam, ncol, pver)
+        call yog_conservation_check(pres_int_cam, tabs_cam, qv_cam, qc_cam, qi_cam, precsfc,  ncol, pver)
         !-----------------------------------------------------
 
         ! Interpolate CAM variables to the SAM pressure levels
@@ -260,7 +264,7 @@ contains
                 presi_col(i, :) = presi(:)*100.0
         end do
         
-        call yog_conservation_check(presi_col, tabs_sam, qv_sam, qc_sam, qi_sam, ncol, nrf)
+        call yog_conservation_check(presi_col, tabs_sam, qv_sam, qc_sam, qi_sam, precsfc, ncol, nrf)
         !-----------------------------------------------------
 
         ! Convert back into CAM variable tendencies (diff div by dtn) on SAM grid
@@ -292,19 +296,22 @@ contains
         allocate(qv_cam_out(ncol_chnk,nver_chnk))
         allocate(qc_cam_out(ncol_chnk,nver_chnk))
         allocate(qi_cam_out(ncol_chnk,nver_chnk))
+        allocate(prec_cam_out(ncol_chnk))
 
         tabs_cam_out = tabs_cam + dtn * ds / cp_cam
         qv_cam_out = qv_cam + dtn * dqv
         qc_cam_out = qc_cam + dtn * dqc
         qi_cam_out = qi_cam + dtn * dqi
+        prec_cam_out = dtn * precsfc
 
         write(iulog, *), "After conversion back:"
-        call yog_conservation_check(pres_int_cam, tabs_cam_out, qv_cam_out, qc_cam_out, qi_cam_out, ncol, pver)
+        call yog_conservation_check(pres_int_cam, tabs_cam_out, qv_cam_out, qc_cam_out, qi_cam_out, prec_cam_out, ncol, pver)
 
         deallocate(tabs_cam_out)
         deallocate(qv_cam_out)
         deallocate(qc_cam_out)
         deallocate(qi_cam_out)
+        deallocate(prec_cam_out)
 
 
 

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -249,7 +249,7 @@ contains
                 presi_col(i, :) = presi(:)
         end do
         
-        call yog_conservation_check(presi_col, tabs_sam, qv_sam, qc_sam, qi_sam, ncol, nz_sam)
+        call yog_conservation_check(presi_col, tabs_sam, qv_sam, qc_sam, qi_sam, ncol, nrf)
         !-----------------------------------------------------
 
         ! Convert back into CAM variable tendencies (diff div by dtn) on SAM grid

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -13,6 +13,9 @@ use SAM_consts_mod, only: nrf, ggr, cp, tbgmax, tbgmin, tprmax, tprmin, &
                           fac_cond, fac_sub, fac_fus, &
                           a_bg, a_pr, an, bn, ap, bp, &
                           omegan, check
+use physconst, only: gravit, cpairv
+use ppgrid, only: pcols, pver, begchunk, endchunk
+use cam_logfile, only: iulog
 
 implicit none
 private
@@ -20,7 +23,7 @@ private
 
 !---------------------------------------------------------------------
 ! public interfaces
-public  nn_convection_flux_CAM, &
+public  nn_convection_flux_CAM, yog_conservation_check, &
         nn_convection_flux_CAM_init, nn_convection_flux_CAM_finalize
 
 ! Make these routines public for purposes of testing,
@@ -71,6 +74,39 @@ contains
 
     end subroutine nn_convection_flux_CAM_init
 
+    subroutine yog_conservation_check(pdel, t, qv, qc, qi, & 
+            ncol)
+
+        real(8), intent(in) :: pdel(:,:)
+        real(8), intent(in) :: t(:,:)
+        real(8), intent(in) :: qv(:,:), qc(:,:), qi(:, :)
+        real(8) :: se(ncol)       ! sum energy
+        real(8) :: sw(ncol)       ! sum water
+        real(8) :: wv(ncol), wl(ncol), wi(ncol)
+
+!        integer, intent(in) :: lchnk                 ! chunk identifier
+        integer, intent(in) :: ncol                  ! number of atmospheric columns
+        integer  i,k                                 ! column, level indices
+
+        do i = 1, ncol
+          se(i) = 0
+          wv(i) = 0
+          wl(i) = 0
+          wi(i) = 0
+          sw(i) = 0
+          do k = 1, pver
+            se(i) = se(i) + t(i,k) *cpairv(i, k, begchunk)*pdel(i,k)/gravit
+            wv(i) = wv(i) + qv(i,k)                       *pdel(i,k)/gravit
+            wl(i) = wl(i) + qc(i,k)                       *pdel(i,k)/gravit
+            wi(i) = wi(i) + qi(i,k)                       *pdel(i,k)/gravit
+            sw(i) = wv(i) + wl(i) + wi(i)
+          end do
+        end do
+
+        write(iulog, *), "Energy sum: ", se
+        write(iulog, *), "Water sum: ", sw
+
+    end subroutine yog_conservation_check
 
     subroutine nn_convection_flux_CAM(pres_cam, pres_int_cam, pres_sfc_cam, &
                                       tabs_cam, qv_cam, qc_cam, qi_cam, &
@@ -126,7 +162,8 @@ contains
 
         ! Initialise precipitation to 0 if required and at start of cycle if subcycling
         precsfc(:)=0.
-
+        !-----------------------------------------------------
+        call yog_conservation_check(pres_cam, tabs_cam, qv_cam, qc_cam, qi_cam, ncol)
         !-----------------------------------------------------
 
         ! Interpolate CAM variables to the SAM pressure levels

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -76,16 +76,17 @@ contains
 
     subroutine yog_conservation_check(p_int, t, qv, qc, qi, & 
             ncol, nver)
+    ! Use this function to check the energy and water conversation by outputting the
+    ! respective sums.  
+    
+        real(8), intent(in) :: p_int(:,:)  ! pressure on grid
+        real(8), intent(in) :: t(:,:) ! temperature
+        real(8), intent(in) :: qv(:,:), qc(:,:), qi(:, :) ! moisture components: water vapor, cloud water, cloud ice
+        real(8) :: pdel(ncol, nver-1)  ! pressure in grid cell
+        real(8) :: se(ncol)       ! sum of energy
+        real(8) :: sw(ncol)       ! sum of water
+        real(8) :: wv(ncol), wl(ncol), wi(ncol)  ! water components: vapor, liquid, ice 
 
-        real(8), intent(in) :: p_int(:,:)
-        real(8), intent(in) :: t(:,:)
-        real(8), intent(in) :: qv(:,:), qc(:,:), qi(:, :)
-        real(8) :: pdel(ncol, nver-1)
-        real(8) :: se(ncol)       ! sum energy
-        real(8) :: sw(ncol)       ! sum water
-        real(8) :: wv(ncol), wl(ncol), wi(ncol)
-
-!        integer, intent(in) :: lchnk                 ! chunk identifier
         integer, intent(in) :: ncol                  ! number of atmospheric columns
         integer, intent(in) :: nver                  ! number of vertical levels
         integer  i,k                                 ! column, level indices
@@ -96,10 +97,11 @@ contains
         wi = 0.0
         sw = 0.0
 
+        ! get the values in the grid cell from those on the edges
         pdel = p_int(:, :nver-1) - p_int(:, 2:nver)
 
-        do i = 1, ncol
-          do k = 1, nver-1
+        do i = 1, ncol ! run over the columns
+          do k = 1, nver-1 ! run over the vertical levels
             se(i) = se(i) + t(i,k) *cpair*pdel(i,k)/gravit
             wv(i) = wv(i) + qv(i,k)      *pdel(i,k)/gravit
             wl(i) = wl(i) + qc(i,k)      *pdel(i,k)/gravit

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -13,7 +13,7 @@ use SAM_consts_mod, only: nrf, ggr, cp, tbgmax, tbgmin, tprmax, tprmin, &
                           fac_cond, fac_sub, fac_fus, &
                           a_bg, a_pr, an, bn, ap, bp, &
                           omegan, check
-use physconst, only: gravit, cpairv
+use physconst, only: gravit, cpairv, cpair
 use ppgrid, only: pcols, pver, begchunk, endchunk
 use cam_logfile, only: iulog
 
@@ -88,17 +88,20 @@ contains
         integer, intent(in) :: ncol                  ! number of atmospheric columns
         integer  i,k                                 ! column, level indices
 
+        se = 0.0
+        wv = 0.0
+        wl = 0.0
+        wi = 0.0
+        sw = 0.0
+
+        pdel_c = pdel(:, pver-1) - pdel(:, 2:pver)
+
         do i = 1, ncol
-          se(i) = 0
-          wv(i) = 0
-          wl(i) = 0
-          wi(i) = 0
-          sw(i) = 0
-          do k = 1, pver
-            se(i) = se(i) + t(i,k) *cpairv(i, k, begchunk)*pdel(i,k)/gravit
-            wv(i) = wv(i) + qv(i,k)                       *pdel(i,k)/gravit
-            wl(i) = wl(i) + qc(i,k)                       *pdel(i,k)/gravit
-            wi(i) = wi(i) + qi(i,k)                       *pdel(i,k)/gravit
+          do k = 1, pver-1
+            se(i) = se(i) + t(i,k) *cpair*pdel_c(i,k)/gravit
+            wv(i) = wv(i) + qv(i,k)      *pdel_c(i,k)/gravit
+            wl(i) = wl(i) + qc(i,k)      *pdel_c(i,k)/gravit
+            wi(i) = wi(i) + qi(i,k)      *pdel_c(i,k)/gravit
             sw(i) = wv(i) + wl(i) + wi(i)
           end do
         end do
@@ -163,7 +166,8 @@ contains
         ! Initialise precipitation to 0 if required and at start of cycle if subcycling
         precsfc(:)=0.
         !-----------------------------------------------------
-        call yog_conservation_check(pres_cam, tabs_cam, qv_cam, qc_cam, qi_cam, ncol)
+        write(iulog, *), "Before conversion:"
+        call yog_conservation_check(pres_int_cam, tabs_cam, qv_cam, qc_cam, qi_cam, ncol)
         !-----------------------------------------------------
 
         ! Interpolate CAM variables to the SAM pressure levels
@@ -234,6 +238,9 @@ contains
         ! Convert precipitation from kg/m^2 to m by dividing by density (1000)
         precsfc = precsfc * 1.0D-3
 
+        !-----------------------------------------------------
+        write(iulog, *), "After conversion:"
+        call yog_conservation_check(presi, tabs_sam, qv_sam, qc_sam, qi_sam, ncol)
         !-----------------------------------------------------
 
         ! Convert back into CAM variable tendencies (diff div by dtn) on SAM grid

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -74,13 +74,13 @@ contains
 
     end subroutine nn_convection_flux_CAM_init
 
-    subroutine yog_conservation_check(pdel, t, qv, qc, qi, & 
+    subroutine yog_conservation_check(p_int, t, qv, qc, qi, & 
             ncol)
 
-        real(8), intent(in) :: pdel(:,:)
+        real(8), intent(in) :: p_int(:,:)
         real(8), intent(in) :: t(:,:)
         real(8), intent(in) :: qv(:,:), qc(:,:), qi(:, :)
-        real(8) :: pdel_c(ncol, pver-1)
+        real(8) :: pdel(ncol, pver-1)
         real(8) :: se(ncol)       ! sum energy
         real(8) :: sw(ncol)       ! sum water
         real(8) :: wv(ncol), wl(ncol), wi(ncol)
@@ -95,14 +95,14 @@ contains
         wi = 0.0
         sw = 0.0
 
-        pdel_c = pdel(:, :pver-1) - pdel(:, 2:pver)
+        pdel = p_int(:, :pver-1) - p_int(:, 2:pver)
 
         do i = 1, ncol
           do k = 1, pver-1
-            se(i) = se(i) + t(i,k) *cpair*pdel_c(i,k)/gravit
-            wv(i) = wv(i) + qv(i,k)      *pdel_c(i,k)/gravit
-            wl(i) = wl(i) + qc(i,k)      *pdel_c(i,k)/gravit
-            wi(i) = wi(i) + qi(i,k)      *pdel_c(i,k)/gravit
+            se(i) = se(i) + t(i,k) *cpair*pdel(i,k)/gravit
+            wv(i) = wv(i) + qv(i,k)      *pdel(i,k)/gravit
+            wl(i) = wl(i) + qc(i,k)      *pdel(i,k)/gravit
+            wi(i) = wi(i) + qi(i,k)      *pdel(i,k)/gravit
             sw(i) = wv(i) + wl(i) + wi(i)
           end do
         end do
@@ -161,6 +161,8 @@ contains
             !! Distance of column from equator (proxy for insolation and sfc albedo)
         real(8), dimension(ncol)      :: precsfc_i
             !! precipitation at surface from one call to parameterisation
+        real(8) :: presi_col(ncol, n_sam_lev)
+            !! presi repeated ncol times along one dimension, for energy and water checker    
 
         integer :: k
 
@@ -241,8 +243,12 @@ contains
 
         !-----------------------------------------------------
         write(iulog, *), "After conversion:"
-        !!presi has just one dimension
-        !!call yog_conservation_check(presi, tabs_sam, qv_sam, qc_sam, qi_sam, ncol)
+        !!presi has just one dimension, so we need to repeat it ncol times to get the required input for the checker
+        do i = 1, ncol
+                presi_col(i, :) = presi(:)
+        end do
+        
+        call yog_conservation_check(presi_col, tabs_sam, qv_sam, qc_sam, qi_sam, ncol)
         !-----------------------------------------------------
 
         ! Convert back into CAM variable tendencies (diff div by dtn) on SAM grid

--- a/src/physics/cam/nn_interface_cam.F90
+++ b/src/physics/cam/nn_interface_cam.F90
@@ -80,6 +80,7 @@ contains
         real(8), intent(in) :: pdel(:,:)
         real(8), intent(in) :: t(:,:)
         real(8), intent(in) :: qv(:,:), qc(:,:), qi(:, :)
+        real(8) :: pdel_c(ncol, pver-1)
         real(8) :: se(ncol)       ! sum energy
         real(8) :: sw(ncol)       ! sum water
         real(8) :: wv(ncol), wl(ncol), wi(ncol)
@@ -94,7 +95,7 @@ contains
         wi = 0.0
         sw = 0.0
 
-        pdel_c = pdel(:, pver-1) - pdel(:, 2:pver)
+        pdel_c = pdel(:, :pver-1) - pdel(:, 2:pver)
 
         do i = 1, ncol
           do k = 1, pver-1


### PR DESCRIPTION
This PR is an implementation of  a water and energy conservation checker to investigate the conservation errors observed in #34 .

The implementation is based on lines [404ff](https://github.com/m2lines/CAM-ML/blob/625f3f33f78d9426146f9ec5a0fe57997aa81498/src/physics/cam/check_energy.F90#L404C1-L410C11) in [check_energy.F09](https://github.com/m2lines/CAM-ML/blob/CAM-ML/src/physics/cam/check_energy.F90).

The checker should be called at various places in [nn_interface_cam.F90->n_convection_flux_CAM](https://github.com/m2lines/CAM-ML/blob/625f3f33f78d9426146f9ec5a0fe57997aa81498/src/physics/cam/nn_interface_cam.F90#L75).

The output can be found in the `atm.log.***.gz` files.