### PR TITLE
Add ML-enabled CLUBB to CAM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -104,7 +104,9 @@
 	url = https://github.com/m2lines/clubb_ML
         fxrequired = AlwaysRequired
         fxsparse = ../.clubb_sparse_checkout
-        fxtag = 0682eb29b987dde2aec928a0be864589abadf119
+        # The commit-hash below is intended to point to the HEAD of branch
+        # 'clubb_4ncar_with_ml' in the mslines/clubb_ML repository.
+        fxtag = 4037452e43e1f32fd24bd1a3067bd2c58a8ce65f
         fxDONOTUSEurl = https://github.com/larson-group/clubb_release
 
 [submodule "ext_co2_cooling"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -101,10 +101,10 @@
 
 [submodule "clubb"]
 	path = src/physics/clubb
-	url = https://github.com/larson-group/clubb_release
+	url = https://github.com/m2lines/clubb_ML
         fxrequired = AlwaysRequired
         fxsparse = ../.clubb_sparse_checkout
-        fxtag = clubb_4ncar_20260109_ddf5110
+        fxtag = 0682eb29b987dde2aec928a0be864589abadf119
         fxDONOTUSEurl = https://github.com/larson-group/clubb_release
 
 [submodule "ext_co2_cooling"]

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3526,6 +3526,8 @@ if ($clubb_sgs  =~ /$TRUE/io) {
    }
 
    add_default($nl, 'clubb_l_ascending_grid');
+   add_default($nl, 'clubb_l_c14_ml');
+   add_default($nl, 'clubb_c14_ml_net_filepath');
    add_default($nl, 'clubb_do_icesuper');
    add_default($nl, 'clubb_do_energyfix');
    add_default($nl, 'clubb_cloudtop_cooling');

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2171,6 +2171,9 @@
 <clubb_do_icesuper                                > .false. </clubb_do_icesuper>
 <clubb_l_ascending_grid                           > .false. </clubb_l_ascending_grid>
 
+<clubb_l_c14_ml                                 > .false. </clubb_l_c14_ml>
+<clubb_c14_ml_net_filepath                      > ''      </clubb_c14_ml_net_filepath>
+
 
 <!-- Lscale_from_tau set by clubb_opts config option -->
 <clubb_l_diag_Lscale_from_tau                     > .false. </clubb_l_diag_Lscale_from_tau>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -4432,6 +4432,16 @@ Exponent for Richardson number in calculation of invrs_tau_wpxp term
 Displacement of log law profile above ground  (units: m)
 </entry>
 
+<entry id="clubb_l_c14_ml" type="logical" category="pblrad"
+       group="clubb_params_nl" valid_values=".true.,.false." >
+Enable inference of CLUBB C14 parameter from machine learning model
+</entry>
+
+<entry id="clubb_c14_ml_net_filepath" type="char*256" category="pblrad"
+       group="clubb_params_nl" valid_values="" >
+Path to machine learning model used to infer CLUBB C14 parameter
+</entry>
+
 <!-- for CLUBB+MF -->
 <entry id="do_clubb_mf" type="logical" category="conv"
        group="clubb_mf_nl" valid_values="" >

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -4437,7 +4437,7 @@ Displacement of log law profile above ground  (units: m)
 Enable inference of CLUBB C14 parameter from machine learning model
 </entry>
 
-<entry id="clubb_c14_ml_net_filepath" type="char*256" category="pblrad"
+<entry id="clubb_c14_ml_net_filepath" type="char*100" category="pblrad"
        group="clubb_params_nl" valid_values="" >
 Path to machine learning model used to infer CLUBB C14 parameter
 </entry>

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -776,8 +776,8 @@ end subroutine clubb_init_cnst
 
     integer :: iunit, read_status, ierr
 
-    logical :: clubb_l_c14_ml 
-    character(len=256) :: clubb_c14_ml_net_filepath
+    logical :: clubb_l_c14_ml
+    character(len=100) :: clubb_c14_ml_net_filepath
 
     namelist /clubb_his_nl/ clubb_history, clubb_rad_history
     namelist /clubbpbl_diff_nl/ clubb_cloudtop_cooling, clubb_rainevap_turb, &

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -775,7 +775,7 @@ end subroutine clubb_init_cnst
     integer :: iunit, read_status, ierr
 
     logical :: clubb_l_c14_ml 
-    character(len=100) :: clubb_c14_ml_net_filepath
+    character(len=256) :: clubb_c14_ml_net_filepath
 
     namelist /clubb_his_nl/ clubb_history, clubb_rad_history
     namelist /clubbpbl_diff_nl/ clubb_cloudtop_cooling, clubb_rainevap_turb, &

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -31,6 +31,8 @@ module clubb_intr
   use ref_pres,            only: top_lev => trop_cloud_top_lev
   use scamMOD,             only: single_column, scm_clubb_iop_name, scm_cambfb_mode
 
+  use advance_xp2_xpyp_module, only: &
+      setup_C14_ML_xp2_xpyp   !------------------------------------------ Procedure(s)
 #ifdef CLUBB_SGS
   use clubb_api_module,    only: pdf_parameter, implicit_coefs_terms, &
                                  clubb_config_flags_type, grid, stats, &
@@ -2051,6 +2053,10 @@ end subroutine clubb_init_cnst
 
     ! The following is physpkg, so it needs to be initialized every time
     call pbuf_set_field(pbuf_ini, fice_idx,    0.0_r8)
+
+    if ( clubb_config_flags%l_c14_ml ) then
+      call setup_C14_ML_xp2_xpyp( clubb_config_flags%c14_ml_net_filepath )
+    end if
 
     ! --------------- !
     ! End             !

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -755,7 +755,7 @@ end subroutine clubb_init_cnst
     use units,           only: getunit, freeunit
     use cam_abortutils,  only: endrun
     use spmd_utils,      only: mpicom, mstrid=>masterprocid, mpi_logical, mpi_real8, &
-                               mpi_integer
+                               mpi_integer, mpi_character
     use clubb_mf,        only: clubb_mf_readnl
 
     use clubb_api_module, only: &
@@ -773,6 +773,9 @@ end subroutine clubb_init_cnst
     logical :: clubb_cloudtop_cooling = .false., clubb_rainevap_turb = .false.
 
     integer :: iunit, read_status, ierr
+
+    logical :: clubb_l_c14_ml 
+    character(len=100) :: clubb_c14_ml_net_filepath
 
     namelist /clubb_his_nl/ clubb_history, clubb_rad_history
     namelist /clubbpbl_diff_nl/ clubb_cloudtop_cooling, clubb_rainevap_turb, &
@@ -899,7 +902,9 @@ end subroutine clubb_init_cnst
          clubb_up2_sfc_coef, &
          clubb_wpxp_L_thresh, &
          clubb_wpxp_Ri_exp, &
-         clubb_z_displace
+         clubb_z_displace, &
+         clubb_l_c14_ml, &
+         clubb_c14_ml_net_filepath
 
     !----- Begin Code -----
 
@@ -978,7 +983,9 @@ end subroutine clubb_init_cnst
                                              clubb_l_mono_flux_lim_spikefix, &  ! Out
                                              clubb_l_host_applies_sfc_fluxes, & ! Out
                                              clubb_l_wp2_fill_holes_tke, & ! Out
-                                             clubb_l_add_dycore_grid ) ! Out
+                                             clubb_l_add_dycore_grid, & ! Out
+                                             clubb_l_c14_ml, & ! Out
+                                             clubb_c14_ml_net_filepath) ! Out
 
     !  Call CLUBB+MF namelist
     call clubb_mf_readnl(nlfile)
@@ -1429,7 +1436,9 @@ end subroutine clubb_init_cnst
                                                  clubb_l_mono_flux_lim_spikefix, &          ! In                      
                                                  clubb_l_host_applies_sfc_fluxes, &         ! In                      
                                                  clubb_l_wp2_fill_holes_tke, &              ! In                  
-                                                 clubb_l_add_dycore_grid, &                 ! In              
+                                                 clubb_l_add_dycore_grid, & 
+                                                 clubb_l_c14_ml, &
+                                                 clubb_c14_ml_net_filepath, &                ! In              
                                                  clubb_config_flags )                       ! Out
 
 #endif


### PR DESCRIPTION
This PR is to properly discuss and review the changes we are making to out base version of CAM (`cam6_4_168` tag). 

Currently I have set the `clubb-ml-main` to align with the commit of the `cam6_4_168`. 

