### PR TITLE
broadcast ml namelist parameters

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -106,7 +106,7 @@
         fxsparse = ../.clubb_sparse_checkout
         # The commit-hash below is intended to point to the HEAD of branch
         # 'clubb_4ncar_with_ml' in the mslines/clubb_ML repository.
-        fxtag = 594a8bf63b0f9669870aa734ccebd58a4e239721
+        fxtag = c35c73e3ac4e3372cc973c33a56bacd26c6f4359
         fxDONOTUSEurl = https://github.com/larson-group/clubb_release
 
 [submodule "ext_co2_cooling"]

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -1296,6 +1296,10 @@ end subroutine clubb_init_cnst
     if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: clubb_l_use_precip_frac")
     call mpi_bcast(clubb_l_uv_nudge, 1, mpi_logical, mstrid, mpicom, ierr)
     if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: clubb_l_uv_nudge")
+    call mpi_bcast(clubb_l_c14_ml, 1, mpi_logical, mstrid, mpicom, ierr)
+    if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: clubb_l_c14_ml")
+    call mpi_bcast(clubb_c14_ml_net_filepath, len(clubb_c14_ml_net_filepath), mpi_character, mstrid, mpicom, ierr)
+    if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: clubb_c14_ml_net_filepath")
 
     !  Overwrite defaults if they are true
     if ( clubb_history          ) stats_metadata%l_stats            = .true.


### PR DESCRIPTION
Adresses #61 
Followed suggested fix by @adconnolly. Quick test with coarse multi column case seems to be working. 
Predicted C14 in all columns through fix, vs only on rank 0:

<img width="895" height="484" alt="image" src="https://github.com/user-attachments/assets/3ba3cfb5-2c47-45ac-acc3-b4d6bd733f37" />
