### PR TITLE
Re-enable 256 character ML paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -106,7 +106,7 @@
         fxsparse = ../.clubb_sparse_checkout
         # The commit-hash below is intended to point to the HEAD of branch
         # 'clubb_4ncar_with_ml' in the mslines/clubb_ML repository.
-        fxtag = c35c73e3ac4e3372cc973c33a56bacd26c6f4359
+        fxtag = ab44dc3fa183f54cfcfcfd300de94cc4804200a8
         fxDONOTUSEurl = https://github.com/larson-group/clubb_release
 
 [submodule "ext_co2_cooling"]

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -4437,7 +4437,7 @@ Displacement of log law profile above ground  (units: m)
 Enable inference of CLUBB C14 parameter from machine learning model
 </entry>
 
-<entry id="clubb_c14_ml_net_filepath" type="char*100" category="pblrad"
+<entry id="clubb_c14_ml_net_filepath" type="char*256" category="pblrad"
        group="clubb_params_nl" valid_values="" >
 Path to machine learning model used to infer CLUBB C14 parameter
 </entry>

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -777,7 +777,7 @@ end subroutine clubb_init_cnst
     integer :: iunit, read_status, ierr
 
     logical :: clubb_l_c14_ml
-    character(len=100) :: clubb_c14_ml_net_filepath
+    character(len=256) :: clubb_c14_ml_net_filepath
 
     namelist /clubb_his_nl/ clubb_history, clubb_rad_history
     namelist /clubbpbl_diff_nl/ clubb_cloudtop_cooling, clubb_rainevap_turb, &


### PR DESCRIPTION
Closes https://github.com/m2lines/clubb_ML/issues/62 

Still draft since should not be merged before https://github.com/m2lines/clubb_ML/pull/67 is and the submodules/.gitmodules still needs updating.  

We can review it approve it now though. Once ready I will just point it to correct upstream before merging.