### PR TITLE
update from to current HEAD of CLUBB_ML

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -106,7 +106,7 @@
         fxsparse = ../.clubb_sparse_checkout
         # The commit-hash below is intended to point to the HEAD of branch
         # 'clubb_4ncar_with_ml' in the mslines/clubb_ML repository.
-        fxtag = ab44dc3fa183f54cfcfcfd300de94cc4804200a8
+        fxtag = fa1e4c8af64a259960616713aad70997a0a90429
         fxDONOTUSEurl = https://github.com/larson-group/clubb_release
 
 [submodule "ext_co2_cooling"]


### PR DESCRIPTION
Updates the tag to include recently merged pr in CLUBB_ML repo: 
- https://github.com/m2lines/clubb_ML/pull/69
- https://github.com/m2lines/clubb_ML/pull/68

